### PR TITLE
A complete Fish installer for pure

### DIFF
--- a/installer.fish
+++ b/installer.fish
@@ -1,34 +1,45 @@
-#!/usr/bin/env fish
+function install_pure
+    test (count $argv) -ge 1;
+        and set FISH_CONFIG_DIR $argv[1];
+        or set FISH_CONFIG_DIR "$HOME/.config/fish"
 
-function install
-    check_git_is_present
-    fetch_source
-    enable_theme
-end
+    test (count $argv) -ge 2;
+        and set PURE_INSTALL_DIR $argv[2];
+        or set PURE_INSTALL_DIR "$FISH_CONFIG_DIR/functions/theme-pure"
 
-function check_git_is_present
+    # Check if 'git' is available
     command --search git >/dev/null 2>&1; or begin;
         printf "Error: git is not installed\n"
         exit 1
     end
-end
 
-function fetch_source
+    # Fetch source
     printf "Fetching theme's source\n"
-    env git clone --depth=1 https://github.com/rafaelrinaldi/theme-pure.git; or begin;
+    env git clone --depth=1 https://github.com/rafaelrinaldi/theme-pure.git $PURE_INSTALL_DIR; or begin;
         printf "Error: git clone of theme-pure repo failed\n"
         exit 1
     end
-end
 
-function enable_theme
+    # Install theme
+    echo "Installing theme"
+
+    #  Ignore previous theme
+    set -l old_prompt $FISH_CONFIG_DIR/functions/fish_prompt.fish
+    if test -f $old_prompt
+        mv $old_prompt $old_prompt.ignore
+        echo "Saved previous fish_prompt.fish to $old_prompt.ignore"
+    end
+
+    #  Enable autoloading for pure's functions on shell init
+    set -l marker "# THEME PURE #"
+    if not test (grep "$THEME_PURE" $FISH_CONFIG_DIR/config.fish 2>&1 >/dev/null)
+        echo "$marker" >> $FISH_CONFIG_DIR/config.fish
+        echo "set fish_function_path $PURE_INSTALL_DIR" '$fish_function_path' >> $FISH_CONFIG_DIR/config.fish
+    end
+    ln -sf $PURE_INSTALL_DIR/fish_prompt.fish $FISH_CONFIG_DIR/functions/
+
+    # Enable theme
     printf "Enabling theme\n"
-    set -l fish_function_path (echo $HOME/.config/fish/functions) $fish_function_path
-    source theme-pure/__format_time.fish
-    source theme-pure/__parse_current_folder.fish
-    source theme-pure/__parse_git_branch.fish
-    source theme-pure/fish_prompt.fish
-    echo "pom"
+    set fish_function_path $PURE_INSTALL_DIR $fish_function_path
+    source $FISH_CONFIG_DIR/functions/fish_prompt.fish
 end
-
-install


### PR DESCRIPTION
Check this out. (in regard to #9)
Instructions (after merge to 'master'):
```fish
curl -Ls https://raw.github.com/rafaelrinaldi/pure/master/installer.fish > pure_installer.fish
and source ./pure_installer; and install_pure
````

On a personal note: this was not fun. letting the framework do all the dirty stuff for you is so much better.

_Edit_: Below are a few of the problems I ran into on the way:

1. Making the `installer.fish` executable and running it with `#/usr/bin/env fish` at the top starts a new Fish shell. Any changes to `fish_function_path` from within that shell are not propagated back up to the original shell process.
2. `set -l fish_function_path (echo $HOME/.config/fish/functions) $fish_function_path` doesn't do much. `$HOME/.config/fish/functions` is already the first entry in `fish_function_path` AFAIK. Also, sub-directories are not read automatically. Perhaps you meant to add the `theme_pure` folder? That would make more sense, but it's better not rely on the user running the installer from `~/.config/fish/functions` or any other specific place.
3. There's no need to source the internal function files if their path is already in `fish_function_path`. Fish will find the files and the functions when they are needed.
4. Sourcing `fish_prompt.fish` once applies the theme in the current shell, but doesn't persist it with future shells. `fish_prompt.fish` must be in some directory that Fish looks for functions in.
5. btw, why `printf` with `\n` on every output and not just use `echo`?

@edouard-lopez I hope that not getting it to work on the first time doesn't take from your motivation to do more with Fish. This is probably not 100% correct either, and I'm not a great Fish expert, but if you have any questions or want to solve any more "cases" together, I'd be happy to lend a hand.
:beers: