### PR TITLE
bugfix: no more 'fatal' error on empty cloned repositories

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -81,10 +81,9 @@ function fish_prompt
     end
 
     # Check if there is an upstream configured
-    set -l has_upstream (command git rev-parse --abbrev-ref @'{u}' ^/dev/null)
-
-    if test -n "$has_upstream"
-      set -l git_status (command git rev-list --left-right --count HEAD...@'{u}' | sed "s/[[:blank:]]/ /" ^/dev/null)
+    command git rev-parse --abbrev-ref '@{upstream}' >/dev/null ^&1; and set -l has_upstream
+    if set -q has_upstream
+      set -l git_status (command git rev-list --left-right --count 'HEAD...@{upstream}' | sed "s/[[:blank:]]/ /" ^/dev/null)
 
       # Resolve Git arrows by treating `git_status` as an array
       set -l git_arrow_left (command echo $git_status | cut -c 1 ^/dev/null)


### PR DESCRIPTION
This is a proposed fix for #11.
`command git rev-parse --abbrev-ref <rev>` will output **<rev>** as it was given if it is not recognized as some ref, revision, or file. Therefore, wrapping it in a `test` will always succeed.
By checking `$status` explicitly we avoid this problem and know if we actually have an upstream or not.