### PR TITLE
Switch to using which instead of command -s

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -63,7 +63,7 @@ function fish_prompt
   end
 
   # Exit with code 1 if git is not available
-  if not command -s git >/dev/null
+  if not which git >/dev/null
     return 1
   end
 


### PR DESCRIPTION
`command -s` is only available in 2.2.0, so using `which` instead of `command -s` would make Pure compatible with most folks that have not upgraded to 2.2.0 for one reason or another.

No reason to keep lingering in 2.1.2, but this change adds support to fish 2.1.2 and possibly lower.