### PR TITLE
Update fisherman install instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ source /tmp/pure_installer.fish; and install_pure
 ### [Fisherman](http://fisherman.sh)
 
 ```fish
-$ fisher install pure
+$ fisher rafaelrinaldi/pure
 ```
 
 ### [Oh My Fish!](https://github.com/oh-my-fish)


### PR DESCRIPTION
fisherman 2.0 dumped the index file in favor of namespace/plugin, [here](https://github.com/fisherman/fisherman/commit/2574ce64d95a249ff09e4100d11e548658e9bf34) is the commit if you want to know about it.

Cheers!