### PR TITLE
Touch config.fish before grepping it. Fix #26.

### DIFF
--- a/installer.fish
+++ b/installer.fish
@@ -50,6 +50,7 @@ end
 function pure::enable_autoloading
     printf "\tEnabling autoloading for pure's functions on shell init"
     set -l marker "# THEME PURE #"
+    touch "$FISH_CONFIG_DIR/config.fish"
     if not test (grep "$THEME_PURE" $FISH_CONFIG_DIR/config.fish 2>&1 >/dev/null)
         echo "$marker" >> $FISH_CONFIG_DIR/config.fish
         echo "set fish_function_path $PURE_INSTALL_DIR" '$fish_function_path' >> $FISH_CONFIG_DIR/config.fish


### PR DESCRIPTION
This will create a config.fish if there isn't one and possibly fix #26.