### PR TITLE
Add username and host to prompt in SSH sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ $ omf install pure
 * Display ⇣ if there are stuff to be pulled
 * Display prompt symbol in red if previous command has failed
 * Display the current folder and command when a process is running
+* Display username and host when in an SSH session
 * Display duration of failed process (defaults to `5`)
 
 ## Configuration
@@ -63,6 +64,17 @@ set pure_color_green (set_color "66ff66")
 set pure_color_normal (set_color "000000")
 set pure_color_red (set_color "f820ff")
 set pure_color_yellow (set_color "1bc8c8")
+
+# Change colors for username and host in SSH
+set pure_username_color $pure_color_yellow
+set pure_host_color $pure_color_green
+set pure_root_color $pure_color_red
+
+# Change where the username and host is displayed
+# 0 - end of prompt, default
+# 1 - start of prompt
+# Any other value defaults to the default behaviour
+set pure_user_host_location 1
 
 # Max execution time of a process before its run time is shown when it exits
 set pure_command_max_exec_time 5

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -49,13 +49,16 @@ function fish_prompt
     set prompt $prompt "\n"
   end
 
+  # Check if user is in an SSH session
   if [ "$SSH_CONNECTION" != "" ]
     set -l host (hostname -s)
     set -l user (whoami)
 
+    # Format user and host part of prompt
     set user_and_host "$pure_color_yellow$user$pure_color_normal@$pure_color_green$host$pure_color_normal "
   end
 
+  # Format user and host on prompt output
   set prompt $prompt $user_and_host
 
   # Format current folder on prompt output

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -36,6 +36,7 @@ function fish_prompt
 
   # Template
 
+  set -l user_and_host ""
   set -l current_folder (__parse_current_folder)
   set -l git_branch_name ""
   set -l git_dirty ""
@@ -47,6 +48,15 @@ function fish_prompt
   if test $__pure_fresh_session -eq 0
     set prompt $prompt "\n"
   end
+
+  if [ "$SSH_CONNECTION" != "" ]
+    set -l host (hostname -s)
+    set -l user (whoami)
+
+    set user_and_host "$pure_color_yellow$user$pure_color_normal@$pure_color_green$host$pure_color_normal "
+  end
+
+  set prompt $prompt $user_and_host
 
   # Format current folder on prompt output
   set prompt $prompt "$pure_color_blue$current_folder$pure_color_normal "

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -24,6 +24,10 @@ __pure_set_default pure_color_cyan (set_color cyan)
 __pure_set_default pure_color_gray (set_color 93A1A1)
 __pure_set_default pure_color_normal (set_color normal)
 
+__pure_set_default pure_username_color $pure_color_gray
+__pure_set_default pure_host_color $pure_color_gray
+__pure_set_default pure_root_color $pure_color_normal
+
 # Max execution time of a process before its run time is shown when it exits
 __pure_set_default pure_command_max_exec_time 5
 
@@ -54,8 +58,14 @@ function fish_prompt
     set -l host (hostname -s)
     set -l user (whoami)
 
+    if [ "$user" = "root" ]
+      set user "$pure_root_color$user"
+    else
+      set user "$pure_username_color$user"
+    end
+
     # Format user and host part of prompt
-    set user_and_host "$pure_color_yellow$user$pure_color_normal@$pure_color_green$host$pure_color_normal "
+    set user_and_host "$user$pure_color_gray@$pure_host_color$host$pure_color_normal "
   end
 
   # Format user and host on prompt output

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -28,6 +28,12 @@ __pure_set_default pure_username_color $pure_color_gray
 __pure_set_default pure_host_color $pure_color_gray
 __pure_set_default pure_root_color $pure_color_normal
 
+# Determines whether the username and host are shown at the begining or end
+# 0 - end of prompt, default
+# 1 - start of prompt
+# Any other value defaults to the default behaviour
+__pure_set_default pure_user_host_location 0
+
 # Max execution time of a process before its run time is shown when it exits
 __pure_set_default pure_command_max_exec_time 5
 
@@ -68,8 +74,9 @@ function fish_prompt
     set user_and_host "$user$pure_color_gray@$pure_host_color$host$pure_color_normal "
   end
 
-  # Format user and host on prompt output
-  set prompt $prompt $user_and_host
+  if test $pure_user_host_location -eq 1
+    set prompt $prompt $user_and_host
+  end
 
   # Format current folder on prompt output
   set prompt $prompt "$pure_color_blue$current_folder$pure_color_normal "
@@ -124,6 +131,10 @@ function fish_prompt
 
     # Format Git prompt output
     set prompt $prompt "$pure_color_gray$git_branch_name$git_dirty$pure_color_normal\t$pure_color_cyan$git_arrows$pure_color_normal"
+  end
+
+  if test $pure_user_host_location -ne 1
+    set prompt $prompt $user_and_host
   end
 
   set prompt $prompt "\n$color_symbol$pure_symbol_prompt$pure_color_normal "


### PR DESCRIPTION
It doesn't follow how the original pure for ZSH does it, but I find having it first thing in the prompt makes it more obvious that you're in an SSH session.