### PR TITLE
Always show execution time for previous command if threshold is exceeded

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -55,11 +55,6 @@ function fish_prompt
   if test $exit_code -ne 0
     # Symbol color is red when previous command fails
     set color_symbol $pure_color_red
-
-    # Prompt failed command execution duration
-    set command_duration (__format_time $CMD_DURATION $pure_command_max_exec_time)
-
-    set prompt $prompt "$pure_color_yellow$command_duration$pure_color_normal"
   end
 
   # Exit with code 1 if git is not available
@@ -91,17 +86,21 @@ function fish_prompt
 
     # If arrow is not "0", it means it's dirty
       if test $git_arrow_left != 0
-        set git_arrows $pure_symbol_git_up_arrow
+        set git_arrows " $pure_symbol_git_up_arrow"
       end
 
       if test $git_arrow_right != 0
-        set git_arrows $git_arrows$pure_symbol_git_down_arrow
+        set git_arrows " $git_arrows$pure_symbol_git_down_arrow"
       end
     end
 
     # Format Git prompt output
-    set prompt $prompt "$pure_color_gray$git_branch_name$git_dirty$pure_color_normal\t$pure_color_cyan$git_arrows$pure_color_normal"
+    set prompt $prompt "$pure_color_gray$git_branch_name$git_dirty$pure_color_normal$pure_color_cyan$git_arrows$pure_color_normal "
   end
+
+  # Prompt command execution duration
+  set command_duration (__format_time $CMD_DURATION $pure_command_max_exec_time)
+  set prompt $prompt "$pure_color_yellow$command_duration$pure_color_normal"
 
   set prompt $prompt "\n$color_symbol$pure_symbol_prompt$pure_color_normal "
 


### PR DESCRIPTION
Execution time for previous command is always shown at the end of the first line of the prompt instead of only being shown when the previous command doesn't exit cleanly.

I also changed the separator between `git_dirty` and `git_arrows` from a tab to a space make it look more similar to [zsh-pure](https://github.com/sindresorhus/pure). I also moved the insertion of that separator to the `git_arrows` variable to avoid double space separators if there was no `git_arrows` inserted.

Here are some screenshots to showcase what has changed:

_This is zsh-pure_
<img width="285" alt="screen shot 2017-02-22 at 18 19 06" src="https://cloud.githubusercontent.com/assets/86396/23223530/984a83b4-f92b-11e6-9501-c86402c8ccf0.png">

_This is fish-pure without the change_
<img width="295" alt="screen shot 2017-02-22 at 18 12 20" src="https://cloud.githubusercontent.com/assets/86396/23223539/9ee9ae70-f92b-11e6-8143-57bd8ca9f1af.png">

_This is fish-pure with the change_
<img width="256" alt="screen shot 2017-02-22 at 18 10 06" src="https://cloud.githubusercontent.com/assets/86396/23223559/ab4ffd86-f92b-11e6-8d2f-21e5c36d438d.png">