### PR TITLE
Better support for vi-mode indicator

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -151,7 +151,10 @@ function fish_prompt
     set prompt $prompt $pure_color_gray(basename "$VIRTUAL_ENV")"$pure_color_normal "
   end
 
-  set prompt $prompt "$color_symbol$pure_symbol_prompt$pure_color_normal "
+  # vi-mode indicator
+  set mode_indicator (fish_default_mode_prompt)
+
+  set prompt $prompt "$mode_indicator$color_symbol$pure_symbol_prompt$pure_color_normal "
 
   echo -e -s $prompt
 


### PR DESCRIPTION
When using this prompt with vi keybindings, the mode-indicator is prepended to the first line of the prompt.

This will put the mode-indicator at the start of the second line, before the '❯' character.