### PR TITLE
Option to show last error as a separate prompt character

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ set pure_root_color $pure_color_red
 # Any other value defaults to the default behaviour
 set pure_user_host_location 1
 
+# Show exit code of last command as a separate prompt character. As described here: https://github.com/sindresorhus/pure/wiki#show-exit-code-of-last-command-as-a-separate-prompt-character
+# 0 - single prompt character, default
+# 1 - separate prompt character
+# Any other value defaults to the default behaviour
+set pure_separate_prompt_on_error 1
+
 # Max execution time of a process before its run time is shown when it exits
 set pure_command_max_exec_time 5
 ```

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -37,6 +37,12 @@ __pure_set_default pure_root_color $pure_color_normal
 # Any other value defaults to the default behaviour
 __pure_set_default pure_user_host_location 0
 
+# Show exit code of last command as a separate prompt character. As described here: https://github.com/sindresorhus/pure/wiki#show-exit-code-of-last-command-as-a-separate-prompt-character
+# 0 - single prompt character, default
+# 1 - separate prompt character
+# Any other value defaults to the default behaviour
+__pure_set_default pure_separate_prompt_on_error 0
+
 # Max execution time of a process before its run time is shown when it exits
 __pure_set_default pure_command_max_exec_time 5
 
@@ -144,6 +150,9 @@ function fish_prompt
   if test $exit_code -ne 0
     # Symbol color is red when previous command fails
     set color_symbol $pure_color_red
+    if test $pure_separate_prompt_on_error -eq 1
+      set color_symbol $pure_color_red$pure_symbol_prompt$pure_color_green
+    end
   end
 
   # Show python virtualenv name (if activated)

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -151,7 +151,10 @@ function fish_prompt
     set prompt $prompt $pure_color_gray(basename "$VIRTUAL_ENV")"$pure_color_normal "
   end
 
-  set prompt $prompt "$color_symbol$pure_symbol_prompt$pure_color_normal "
+  # vi-mode indicator
+  set mode_indicator (fish_default_mode_prompt)
+
+  set prompt $prompt "$mode_indicator$color_symbol$pure_symbol_prompt$pure_color_normal "
 
   echo -e -s $prompt
 


### PR DESCRIPTION
As mentioned here: https://github.com/sindresorhus/pure/wiki#show-exit-code-of-last-command-as-a-separate-prompt-character