### PR TITLE
Check for CMD_DURATION before calling __format_time

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -133,7 +133,9 @@ function fish_prompt
   end
 
   # Prompt command execution duration
-  set command_duration (__format_time $CMD_DURATION $pure_command_max_exec_time)
+  if test -n "$CMD_DURATION"
+    set command_duration (__format_time $CMD_DURATION $pure_command_max_exec_time)
+  end
   set prompt $prompt "$pure_color_yellow$command_duration$pure_color_normal"
 
   set prompt $prompt "\n$color_symbol$pure_symbol_prompt$pure_color_normal "


### PR DESCRIPTION
In [fish < 2.5.0](https://github.com/fish-shell/fish-shell/commit/573916e5e29163f155d07dfd67372ab68686c98e), the `CMD_DURATION` variable has no value when first opening a shell session, therefore we check if it's been initialized before passing it to `__format_time`, to ensure backwards-compatibility.