### PR TITLE
Add support for python virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ $ omf install pure
 * Display the current folder and command when a process is running
 * Display username and host when in an SSH session
 * Display duration of failed process (defaults to `5`)
+* Display python virtualenv name if activated
 
 ## Configuration
 

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -6,6 +6,9 @@
 # Whether or not is a fresh session
 set -g __pure_fresh_session 1
 
+# Deactivate the default virtualenv prompt so that we can add our own
+set -gx VIRTUAL_ENV_DISABLE_PROMPT 1
+
 # Symbols
 
 __pure_set_default pure_symbol_prompt "❯"
@@ -136,9 +139,14 @@ function fish_prompt
   if test -n "$CMD_DURATION"
     set command_duration (__format_time $CMD_DURATION $pure_command_max_exec_time)
   end
-  set prompt $prompt "$pure_color_yellow$command_duration$pure_color_normal"
+  set prompt $prompt "$pure_color_yellow$command_duration$pure_color_normal\n"
 
-  set prompt $prompt "\n$color_symbol$pure_symbol_prompt$pure_color_normal "
+  # Show python virtualenv name (if activated)
+  if test -n "$VIRTUAL_ENV"
+    set prompt $prompt $pure_color_gray(basename "$VIRTUAL_ENV")"$pure_color_normal "
+  end
+
+  set prompt $prompt "$color_symbol$pure_symbol_prompt$pure_color_normal "
 
   echo -e -s $prompt
 


### PR DESCRIPTION
This PR solves #50 by showing the virtualenv name before the prompt symbol:

### Before
<img width="443" alt="before" src="https://cloud.githubusercontent.com/assets/3471625/25772443/fb0ffe2a-326a-11e7-88f5-24393d9dc1e8.png">

### After
<img width="446" alt="after" src="https://cloud.githubusercontent.com/assets/3471625/25772442/fb08f9a4-326a-11e7-8540-f8753c235ecc.png">



