### PR TITLE
Improve structure of travis configuration and remove `dist: xenial` option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: c
 sudo: required
 before_install:
-    - sudo add-apt-repository -y ppa:fish-shell/release-2
-    - sudo apt-get update
-    - sudo apt-get -y install fish
+  - sudo add-apt-repository -y ppa:fish-shell/release-2
+  - sudo apt-get update
+install:
+  - sudo apt-get -y install fish
+  - curl -Lo ~/.config/fish/functions/fisher.fish --create-dirs git.io/fisherman
 script:
-    - curl -Lo ~/.config/fish/functions/fisher.fish --create-dirs git.io/fisherman
-    - fish -c "fisher fishtape .; fishtape tests/*.test.fish"
+  - fish -c "fisher fishtape .; fishtape tests/*.test.fish"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ before_install:
   - sudo apt-get update
 install:
   - sudo apt-get -y install fish
-  - curl -Lo ~/.config/fish/functions/fisher.fish --create-dirs git.io/fisherman
+  - curl -Lo ~/.config/fish/functions/fisher.fish --create-dirs git.io/fisher
 script:
   - fish -c "fisher fishtape .; fishtape tests/*.test.fish"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+language: c
 sudo: required
 before_install:
     - sudo add-apt-repository -y ppa:fish-shell/release-2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: xenial
 sudo: required
 before_install:
     - sudo add-apt-repository -y ppa:fish-shell/release-2

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ before_install:
 install:
   - sudo apt-get -y install fish
   - curl -Lo ~/.config/fish/functions/fisher.fish --create-dirs git.io/fisher
+  - fish -c "fisher fishtape"
 script:
-  - fish -c "fisher fishtape .; fishtape tests/*.test.fish"
+  - fish -c "fishtape tests/*.test.fish"


### PR DESCRIPTION
I took the liberty of creating a pull request before receiving a respons to #71, as this is only small change in the travis configuration. The main change is the removal of the `dist: xenial` option, which is currently unstable and, according to maintainers of travis, only added for experimental reasons. See #71.

I also moved some of the existing configuration to, in my opinion, more logical travis lifecycle steps. I also updated the fisherman installation url to the one used in the installation guid of the fisherman repo (the one previously used linked to the 2.9.0 release, while the new url links to the master branch. Finally I added `language: c`. I think ruby is the default language if it's not provided, and setting the language to c ensures a small (short) environment setup.

This should fix #71 