### PR TITLE
Test fundle install and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,22 +16,24 @@
 Via [cURL](https://curl.haxx.se):
 
 ```sh
-$ # Download the installer to `/tmp`
-$ curl -Ls https://raw.github.com/rafaelrinaldi/pure/master/installer.fish > /tmp/pure_installer.fish
-$ # Source and trigger the installer
-$ source /tmp/pure_installer.fish; and install_pure
+# Download the installer to `/tmp`
+curl -Ls https://raw.github.com/rafaelrinaldi/pure/master/installer.fish > /tmp/pure_installer.fish
+# Source and trigger the installer
+source /tmp/pure_installer.fish; and install_pure
 ```
 
 ### [Fisherman](https://fisherman.github.io)
 
 ```fish
-$ fisher rafaelrinaldi/pure
+fisher rafaelrinaldi/pure
 ```
 
 ### [Oh My Fish!](https://github.com/oh-my-fish)
 
 ```fish
-$ omf install pure
+omf install pure
+```
+
 ### [Fundle](https://github.com/tuvistavie/fundle)
 
 ```fish

--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ $ fisher rafaelrinaldi/pure
 
 ```fish
 $ omf install pure
+### [Fundle](https://github.com/tuvistavie/fundle)
+
+```fish
+fundle plugin rafaelrinaldi/pure;
+fundle install;
 ```
 
 ## Features

--- a/tests/ci.test.fish
+++ b/tests/ci.test.fish
@@ -40,3 +40,19 @@ test "install with OMF (Oh-My-Fish!)"
         ' | grep --only-matching 'pure successfully installed'
     )
 end
+
+test "install with Fundle"
+    'Installing rafaelrinaldi/pure' = (
+        docker run \
+            --name pure \
+            --rm \
+            --tty \
+            edouardlopez/pure-fish '
+                mkdir -p ~/.config/fish/functions;
+                wget https://git.io/fundle -O ~/.config/fish/functions/fundle.fish;
+                fundle plugin rafaelrinaldi/pure;
+                fundle install;
+                fundle list -s
+        ' | grep --only-matching 'Installing rafaelrinaldi/pure'
+    )
+end

--- a/tests/ci.test.fish
+++ b/tests/ci.test.fish
@@ -1,6 +1,4 @@
-function setup
-    docker pull edouardlopez/pure-fish
-end
+docker pull edouardlopez/pure-fish
 
 test "install manually (default behaviour of `docker-pure-fish`)"
     'version' = (


### PR DESCRIPTION
Missing in #78:
* add a test to install with `fundle`
* update doc with `fundle` commands

I will release a `1.8.0` once merged