### PR TITLE
Fix compatibility with fish 3

### DIFF
--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -89,20 +89,20 @@ function pre_prompt --on-event fish_prompt
   end
 
   # Check if is on a Git repository
-  set -l is_git_repository (command git rev-parse --is-inside-work-tree ^/dev/null)
+  set -l is_git_repository (command git rev-parse --is-inside-work-tree 2>/dev/null)
 
   if test -n "$is_git_repository"
     set git_branch_name (__parse_git_branch)
 
     # Check if there are files to commit
-    set -l is_git_dirty (command git status --porcelain --ignore-submodules ^/dev/null)
+    set -l is_git_dirty (command git status --porcelain --ignore-submodules 2>/dev/null)
 
     if test -n "$is_git_dirty"
       set git_dirty $pure_symbol_git_dirty
     end
 
     # Check if there is an upstream configured
-    command git rev-parse --abbrev-ref '@{upstream}' >/dev/null ^&1; and set -l has_upstream
+    command git rev-parse --abbrev-ref '@{upstream}' >/dev/null 2>&1; and set -l has_upstream
     if set -q has_upstream
       command git rev-list --left-right --count 'HEAD...@{upstream}' | read -la git_status
 

--- a/functions/__format_time.fish
+++ b/functions/__format_time.fish
@@ -1,9 +1,9 @@
 function __format_time -d "Format milliseconds to a human readable format"
   set -l milliseconds $argv[1]
-  set -l seconds (math "$milliseconds / 1000 % 60")
-  set -l minutes (math "$milliseconds / 60000 % 60")
-  set -l hours (math "$milliseconds / 3600000 % 24")
-  set -l days (math "$milliseconds / 86400000")
+  set -l seconds (math -s0 "$milliseconds / 1000 % 60")
+  set -l minutes (math -s0 "$milliseconds / 60000 % 60")
+  set -l hours (math -s0 "$milliseconds / 3600000 % 24")
+  set -l days (math -s0 "$milliseconds / 86400000")
   set -l time
   set -l threshold $argv[2]
 

--- a/functions/__parse_git_branch.fish
+++ b/functions/__parse_git_branch.fish
@@ -1,4 +1,4 @@
 function __parse_git_branch -d "Parse current Git branch name"
-  command git symbolic-ref --short HEAD ^/dev/null;
+  command git symbolic-ref --short HEAD 2>/dev/null;
     or echo (command git show-ref --head -s --abbrev HEAD)[1]
 end


### PR DESCRIPTION
Hi!

The upcoming fish 3 has a rather large number of changes, some of them not entirely backwards compatible.

Among them:

- `^` to redirect stderr is deprecated and can be turned off via a new "feature flags" system. The intention is to default it to off in the next major release after 3.0, and to remove it entirely in the one after that.

- `math` is now a builtin (which makes pure about 5x faster), and defaults to float output (with trailing 0s removed - so e.g. `5.0000` will come out as `5`)

Pure hits both of this, this PR rectifies that.

I'm not sure if you still support fish < 2.4 (meaning 2.3, as that's what introduced `string`), the second commit requires 2.4. If you prefer, I can add a solution using `string` that's a teensy bit uglier.