### PR TITLE
Change hostname variable name to avoid scope error

### DIFF
--- a/functions/_pure_prompt_host.fish
+++ b/functions/_pure_prompt_host.fish
@@ -1,5 +1,6 @@
 function _pure_prompt_host
-    set --local hostname (hostname -s) # current host name
+    set -qg hostname
+    or set --local hostname (hostname -s) # current host name
     set --local hostname_color "$pure_host_color"
 
     echo "$hostname_color$hostname"


### PR DESCRIPTION
All credit to @comfortablynick, this is a workaround to #98 being block due to invisible conflict

> Latest nightly build of Fish gives error 
>
>     tried to modify the special variable hostname with the wrong scope. 
> This changes the variable from `hostname` to `host` and `hostname_color` to `host_color` to match.

![selection_219](https://user-images.githubusercontent.com/1212392/49903365-45be8300-fe67-11e8-83ce-2a3d42d62f49.png)
