### PR TITLE
Make possible to customize fish_right_prompt

### DIFF
--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -1,4 +1,4 @@
-set --universal pure_version 1.12.0
+set --universal pure_version 1.13.0
 
 # Whether or not is a fresh session
 set --global _pure_fresh_session true

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -53,3 +53,7 @@ _pure_set_default pure_separate_prompt_on_error false
 
 # Max execution time of a process before its run time is shown when it exits
 _pure_set_default pure_command_max_exec_time 5
+
+# Right Prompt variables
+_pure_set_default pure_right_prompt ""
+_pure_set_default pure_right_prompt_color pure_color_normal

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -56,4 +56,4 @@ _pure_set_default pure_command_max_exec_time 5
 
 # Right Prompt variables
 _pure_set_default pure_right_prompt ""
-_pure_set_default pure_right_prompt_color $pure_color_normal
+_pure_set_default pure_color_right_prompt $pure_color_normal

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -56,4 +56,4 @@ _pure_set_default pure_command_max_exec_time 5
 
 # Right Prompt variables
 _pure_set_default pure_right_prompt ""
-_pure_set_default pure_right_prompt_color pure_color_normal
+_pure_set_default pure_right_prompt_color $pure_color_normal

--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -1,3 +1,8 @@
 # Removes right prompt
 function fish_right_prompt
+    set_color $pure_right_prompt_color
+
+    echo "$pureright_prompt"
+
+    set_color normal
 end

--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -1,8 +1,5 @@
-# Removes right prompt
-function fish_right_prompt
-    set_color $pure_right_prompt_color
+function fish_right_prompt \
+    --description "Let user override prompt"
 
-    echo "$pureright_prompt"
-
-    set_color normal
+    printf "%s%s%s" $pure_color_right_prompt "$pure_right_prompt" $pure_color_normal
 end

--- a/tests/_pure.test.fish
+++ b/tests/_pure.test.fish
@@ -188,3 +188,15 @@ test "configure: pure_command_max_exec_time"
         echo $pure_command_max_exec_time
     ) = 5
 end
+
+test "configure: pure_right_prompt" 
+    (
+        echo $pure_right_prompt
+    ) = ""
+end
+
+test "configure: pure_color_right_prompt" 
+    (
+        echo $pure_color_right_prompt
+    ) = (set_color normal)
+end

--- a/tests/fish_right_prompt.test.fish
+++ b/tests/fish_right_prompt.test.fish
@@ -1,0 +1,29 @@
+source $DIRNAME/../fish_right_prompt.fish
+
+set --local empty ''
+
+test "fish_right_prompt: succeed"
+    (
+        fish_right_prompt 2>&1 >/dev/null
+    ) $status -eq 0
+end
+
+test "fish_right_prompt: prints $pure_color_right_prompt"
+    (
+        set pure_right_prompt "🐙"  # U+1F419 OCTOPUS
+        set pure_color_right_prompt $empty
+        set pure_color_normal $empty
+
+        fish_right_prompt
+    ) = '🐙'
+end
+
+test "fish_right_prompt: prints colorful right_prompt"
+    (
+        set pure_right_prompt "🐬"  # U+1F42C DOLPHIN
+        set pure_color_right_prompt (set_color blue)
+        set pure_color_normal (set_color normal)
+
+        fish_right_prompt
+    ) = (set_color blue)'🐬'(set_color normal)
+end


### PR DESCRIPTION
**related:** #87

---

Issue:
* Updating pure overrides the `fish_right_prompt.fish` file, replacing
it with it's own content

Why:
* It's annoying that we need to set it again once we update pure

Improvements
* Add `pure_right_prompt` customizing the message
* Add `pure_right_prompt_color` customizing the color of the message

Example:

```
set pure_right_prompt '['(rbenv version-name)']'
set pure_right_prompt_color red
```

Outcome:
<img width="712" alt="image" src="https://user-images.githubusercontent.com/748089/50214933-7a57a080-0379-11e9-90bc-90193b682c8c.png">
