### PR TITLE
replace fisherman with fisher

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -17,7 +17,7 @@ RUN curl \
     --location \
     --output $HOME/.config/fish/functions/fisher.fish \
     --create-dirs \
-    git.io/fisherman \
-    && fish -c 'fisher install fishtape'
+    git.io/fisher \
+    && fish -c 'fisher add jorgebucaran/fishtape'
 
 CMD ["fish", "-c", "fishtape tests/installer.test.fish"]


### PR DESCRIPTION
Script was still using old `fisherman`.

Is it ok with you @jorgebucaran ?