### PR TITLE
Revise the vi mode indicator to ❮ for non-insert modes

### DIFF
--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -13,6 +13,7 @@ _pure_set_default pure_color_dark (set_color black)
 
 # Prompt
 _pure_set_default pure_symbol_prompt "❯"
+_pure_set_default pure_symbol_reverse "❮"
 _pure_set_default pure_color_prompt_on_error $pure_color_danger
 _pure_set_default pure_color_prompt_on_success $pure_color_success
 
@@ -56,6 +57,11 @@ _pure_set_default pure_color_command_duration $pure_color_warning
 # Right Prompt variables
 _pure_set_default pure_right_prompt ""
 _pure_set_default pure_color_right_prompt $pure_color_normal
+
+# vi mode indicator
+# true (default):  indicate a non-insert mode by reversing the prompt symbol (❮)
+# false:           indicate vi mode with [I], [N], [V]  
+_pure_set_default pure_reverse_prompt_symbol_in_vimode true
 
 # Title
 _pure_set_default pure_symbol_title_bar_separator "—"

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -13,7 +13,7 @@ _pure_set_default pure_color_dark (set_color black)
 
 # Prompt
 _pure_set_default pure_symbol_prompt "❯"
-_pure_set_default pure_symbol_reverse "❮"
+_pure_set_default pure_symbol_reverse_prompt "❮"  # used for VI mode
 _pure_set_default pure_color_prompt_on_error $pure_color_danger
 _pure_set_default pure_color_prompt_on_success $pure_color_success
 
@@ -58,7 +58,7 @@ _pure_set_default pure_color_command_duration $pure_color_warning
 _pure_set_default pure_right_prompt ""
 _pure_set_default pure_color_right_prompt $pure_color_normal
 
-# vi mode indicator
+# VI mode indicator
 # true (default):  indicate a non-insert mode by reversing the prompt symbol (❮)
 # false:           indicate vi mode with [I], [N], [V]  
 _pure_set_default pure_reverse_prompt_symbol_in_vimode true

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -1,4 +1,4 @@
-set --universal pure_version 2.0.2 # used for bug report
+set --universal pure_version 2.1.0 # used for bug report
 
 # Base colors
 _pure_set_default pure_color_primary (set_color blue)

--- a/functions/_pure_get_prompt_symbol.fish
+++ b/functions/_pure_get_prompt_symbol.fish
@@ -4,7 +4,7 @@ function _pure_get_prompt_symbol \
 
     set --local prompt_symbol $pure_symbol_prompt
     set --local is_vi_mode (string match fish_{vi,hybrid}_key_bindings $fish_key_bindings)
-    if test is_vi_mode \
+    if test -n "$is_vi_mode" \
             -a "$pure_reverse_prompt_symbol_in_vimode" = true \
             -a "$fish_bind_mode" != "insert"
         set prompt_symbol $pure_symbol_reverse_prompt

--- a/functions/_pure_get_prompt_symbol.fish
+++ b/functions/_pure_get_prompt_symbol.fish
@@ -1,0 +1,14 @@
+function _pure_get_prompt_symbol \
+    --description 'Print prompt symbol' \
+    --argument-names exit_code
+
+    set --local prompt_symbol $pure_symbol_prompt # default pure symbol (`❯`)
+    set --local is_vi_mode (string match fish_{vi,hybrid}_key_bindings $fish_key_bindings)
+    if test is_vi_mode \
+            -a "$pure_reverse_prompt_symbol_in_vimode" = true \
+            -a "$fish_bind_mode" != "insert"
+        set prompt_symbol $pure_symbol_reverse # default reverse symbol `❮`
+    end
+
+    echo "$prompt_symbol"
+end

--- a/functions/_pure_get_prompt_symbol.fish
+++ b/functions/_pure_get_prompt_symbol.fish
@@ -2,12 +2,12 @@ function _pure_get_prompt_symbol \
     --description 'Print prompt symbol' \
     --argument-names exit_code
 
-    set --local prompt_symbol $pure_symbol_prompt # default pure symbol (`❯`)
+    set --local prompt_symbol $pure_symbol_prompt
     set --local is_vi_mode (string match fish_{vi,hybrid}_key_bindings $fish_key_bindings)
     if test is_vi_mode \
             -a "$pure_reverse_prompt_symbol_in_vimode" = true \
             -a "$fish_bind_mode" != "insert"
-        set prompt_symbol $pure_symbol_reverse # default reverse symbol `❮`
+        set prompt_symbol $pure_symbol_reverse_prompt
     end
 
     echo "$prompt_symbol"

--- a/functions/_pure_prompt_symbol.fish
+++ b/functions/_pure_prompt_symbol.fish
@@ -2,33 +2,23 @@ function _pure_prompt_symbol \
     --description 'Print prompt symbol' \
     --argument-names exit_code
 
-    set --local reverse_symbol_instead_of_default_mode_prompt $pure_reverse_prompt_symbol_in_vimode
-    set --local pure_symbol $pure_symbol_prompt
-    set --local pure_symbol_reverse $pure_symbol_reverse
-
+    set --local pure_symbol $pure_symbol_prompt # default pure symbol (`❯`)
+    set --local is_vi_mode (string match fish_{vi,hybrid}_key_bindings $fish_key_bindings)
+    if test is_vi_mode \
+      -a $pure_reverse_prompt_symbol_in_vimode \
+      -a "$fish_bind_mode" != "insert"
+        set pure_symbol $pure_symbol_reverse # default reverse symbol `❮`
+    end
     set --local command_succeed 0
 
     set --local color_symbol $pure_color_prompt_on_success # default pure symbol color
     if test $exit_code -ne 0
         set color_symbol $pure_color_prompt_on_error  # different pure symbol color when previous command failed
 
-        if test "$pure_separate_prompt_on_error" = true
-            set color_symbol "$pure_color_prompt_on_error$pure_symbol_prompt$pure_color_prompt_on_success"
+        if test $pure_separate_prompt_on_error = true
+            set color_symbol "$pure_color_symbol_error$pure_symbol$pure_color_symbol_success"
         end
     end
 
-    if test reverse_symbol_instead_of_default_mode_prompt
-      # Do nothing if not in vi mode
-      if test "$fish_key_bindings" = "fish_vi_key_bindings"
-          or test "$fish_key_bindings" = "fish_hybrid_key_bindings"
-          if test "$fish_bind_mode" = "insert"
-              echo "$color_symbol$pure_symbol"
-          else
-              echo "$color_symbol$pure_symbol_reverse"
-          end
-      end
-
-    else
-      echo "$color_symbol$pure_symbol"
-    end
+    echo "$color_symbol$pure_symbol"
 end

--- a/functions/_pure_prompt_symbol.fish
+++ b/functions/_pure_prompt_symbol.fish
@@ -2,23 +2,23 @@ function _pure_prompt_symbol \
     --description 'Print prompt symbol' \
     --argument-names exit_code
 
-    set --local pure_symbol $pure_symbol_prompt # default pure symbol (`❯`)
+    set --local prompt_symbol $pure_symbol_prompt # default pure symbol (`❯`)
     set --local is_vi_mode (string match fish_{vi,hybrid}_key_bindings $fish_key_bindings)
     if test is_vi_mode \
-      -a $pure_reverse_prompt_symbol_in_vimode \
-      -a "$fish_bind_mode" != "insert"
-        set pure_symbol $pure_symbol_reverse # default reverse symbol `❮`
+            -a $pure_reverse_prompt_symbol_in_vimode \
+            -a "$fish_bind_mode" != "insert"
+        set prompt_symbol $pure_symbol_reverse # default reverse symbol `❮`
     end
-    set --local command_succeed 0
 
+    set --local command_succeed 0
     set --local color_symbol $pure_color_prompt_on_success # default pure symbol color
-    if test $exit_code -ne 0
+    if test $exit_code -ne $command_succeed
         set color_symbol $pure_color_prompt_on_error  # different pure symbol color when previous command failed
 
-        if test $pure_separate_prompt_on_error = true
-            set color_symbol "$pure_color_symbol_error$pure_symbol$pure_color_symbol_success"
+        if test "$pure_separate_prompt_on_error" = true
+            set color_symbol "$pure_color_symbol_error$prompt_symbol$pure_color_symbol_success"
         end
     end
 
-    echo "$color_symbol$pure_symbol"
+    echo "$color_symbol$prompt_symbol"
 end

--- a/functions/_pure_prompt_symbol.fish
+++ b/functions/_pure_prompt_symbol.fish
@@ -9,7 +9,7 @@ function _pure_prompt_symbol \
         set color_symbol $pure_color_prompt_on_error  # different pure symbol color when previous command failed
 
         if test "$pure_separate_prompt_on_error" = true
-            set color_symbol "$pure_color_symbol_error$prompt_symbol$pure_color_symbol_success"
+            set color_symbol "$pure_color_prompt_on_error$prompt_symbol$pure_color_prompt_on_success"
         end
     end
 

--- a/functions/_pure_prompt_symbol.fish
+++ b/functions/_pure_prompt_symbol.fish
@@ -2,14 +2,7 @@ function _pure_prompt_symbol \
     --description 'Print prompt symbol' \
     --argument-names exit_code
 
-    set --local prompt_symbol $pure_symbol_prompt # default pure symbol (`❯`)
-    set --local is_vi_mode (string match fish_{vi,hybrid}_key_bindings $fish_key_bindings)
-    if test is_vi_mode \
-            -a $pure_reverse_prompt_symbol_in_vimode \
-            -a "$fish_bind_mode" != "insert"
-        set prompt_symbol $pure_symbol_reverse # default reverse symbol `❮`
-    end
-
+    set --local prompt_symbol (_pure_get_prompt_symbol)
     set --local command_succeed 0
     set --local color_symbol $pure_color_prompt_on_success # default pure symbol color
     if test $exit_code -ne $command_succeed

--- a/functions/_pure_prompt_symbol.fish
+++ b/functions/_pure_prompt_symbol.fish
@@ -2,7 +2,10 @@ function _pure_prompt_symbol \
     --description 'Print prompt symbol' \
     --argument-names exit_code
 
+    set --local reverse_symbol_instead_of_default_mode_prompt $pure_reverse_prompt_symbol_in_vimode
     set --local pure_symbol $pure_symbol_prompt
+    set --local pure_symbol_reverse $pure_symbol_reverse
+
     set --local command_succeed 0
 
     set --local color_symbol $pure_color_prompt_on_success # default pure symbol color
@@ -14,5 +17,18 @@ function _pure_prompt_symbol \
         end
     end
 
-    echo "$color_symbol$pure_symbol"
+    if test reverse_symbol_instead_of_default_mode_prompt
+      # Do nothing if not in vi mode
+      if test "$fish_key_bindings" = "fish_vi_key_bindings"
+          or test "$fish_key_bindings" = "fish_hybrid_key_bindings"
+          if test "$fish_bind_mode" = "insert"
+              echo "$color_symbol$pure_symbol"
+          else
+              echo "$color_symbol$pure_symbol_reverse"
+          end
+      end
+
+    else
+      echo "$color_symbol$pure_symbol"
+    end
 end

--- a/functions/_pure_prompt_vimode.fish
+++ b/functions/_pure_prompt_vimode.fish
@@ -1,3 +1,6 @@
 function _pure_prompt_vimode
-    echo (fish_default_mode_prompt)
+    set --local reverse_symbol_instead_of_default_mode_prompt $pure_reverse_prompt_symbol_in_vimode
+    if test ! reverse_symbol_instead_of_default_mode_prompt
+      echo (fish_default_mode_prompt)
+    end
 end

--- a/functions/_pure_prompt_vimode.fish
+++ b/functions/_pure_prompt_vimode.fish
@@ -1,6 +1,5 @@
 function _pure_prompt_vimode
-    set --local reverse_symbol_instead_of_default_mode_prompt $pure_reverse_prompt_symbol_in_vimode
-    if test ! reverse_symbol_instead_of_default_mode_prompt
+    if test ! $pure_reverse_prompt_symbol_in_vimode
       echo (fish_default_mode_prompt)
     end
 end

--- a/tests/_pure.test.fish
+++ b/tests/_pure.test.fish
@@ -34,7 +34,7 @@ set --local empty ''
 
 @test "configure: pure_reverse_prompt_symbol_in_vimode" (
         set --erase pure_reverse_prompt_symbol_in_vimode
-        source $DIRNAME/../conf.d/pure.fish
+        source $current_dirname/../conf.d/pure.fish
         echo $pure_reverse_prompt_symbol_in_vimode
     ) = true
 

--- a/tests/_pure.test.fish
+++ b/tests/_pure.test.fish
@@ -26,6 +26,18 @@ set --local empty ''
     echo $pure_symbol_prompt
 ) = "❯"
 
+@test "configure: pure_symbol_reverse"  (
+    set --erase pure_symbol_reverse
+    source $current_dirname/../conf.d/pure.fish
+    echo $pure_symbol_reverse
+) = "❮"
+
+@test "configure: pure_reverse_prompt_symbol_in_vimode" (
+        set --erase pure_reverse_prompt_symbol_in_vimode
+        source $DIRNAME/../conf.d/pure.fish
+        echo $pure_reverse_prompt_symbol_in_vimode
+    ) = true
+
 @test "configure: pure_symbol_git_unpulled_commits"  (
     set --erase pure_symbol_git_unpulled_commits
     source $current_dirname/../conf.d/pure.fish

--- a/tests/_pure.test.fish
+++ b/tests/_pure.test.fish
@@ -26,10 +26,10 @@ set --local empty ''
     echo $pure_symbol_prompt
 ) = "❯"
 
-@test "configure: pure_symbol_reverse"  (
-    set --erase pure_symbol_reverse
+@test "configure: pure_symbol_reverse_prompt"  (
+    set --erase pure_symbol_reverse_prompt
     source $current_dirname/../conf.d/pure.fish
-    echo $pure_symbol_reverse
+    echo $pure_symbol_reverse_prompt
 ) = "❮"
 
 @test "configure: pure_reverse_prompt_symbol_in_vimode" (

--- a/tests/_pure_get_prompt_symbol.test.fish
+++ b/tests/_pure_get_prompt_symbol.test.fish
@@ -8,7 +8,7 @@ source $current_dirname/../functions/_pure_get_prompt_symbol.fish
 
 @test "_pure_get_prompt_symbol: get vi-mode symbol ❮" (
     set pure_reverse_prompt_symbol_in_vimode true
-    set pure_symbol_reverse '❮'
+    set pure_symbol_reverse_prompt '❮'
     
     _pure_get_prompt_symbol
 ) = '❮'

--- a/tests/_pure_get_prompt_symbol.test.fish
+++ b/tests/_pure_get_prompt_symbol.test.fish
@@ -1,0 +1,14 @@
+source $current_dirname/../functions/_pure_get_prompt_symbol.fish
+
+@test "_pure_get_prompt_symbol: get default symbol ❯" (
+    set pure_symbol_prompt '❯'
+
+    _pure_get_prompt_symbol
+) = '❯'
+
+@test "_pure_get_prompt_symbol: get vi-mode symbol ❮" (
+    set pure_reverse_prompt_symbol_in_vimode true
+    set pure_symbol_reverse '❮'
+    
+    _pure_get_prompt_symbol
+) = '❮'

--- a/tests/_pure_get_prompt_symbol.test.fish
+++ b/tests/_pure_get_prompt_symbol.test.fish
@@ -1,14 +1,41 @@
 source $current_dirname/../functions/_pure_get_prompt_symbol.fish
 
+function setup
+    set --global pure_symbol_prompt '❯'
+    set --global pure_symbol_reverse_prompt '❮'
+end
+
+function teardown
+    set fish_key_bindings fish_default_key_bindings
+    set fish_bind_mode 'default'
+end
+
 @test "_pure_get_prompt_symbol: get default symbol ❯" (
-    set pure_symbol_prompt '❯'
+    set pure_reverse_prompt_symbol_in_vimode false
 
     _pure_get_prompt_symbol
 ) = '❯'
 
-@test "_pure_get_prompt_symbol: get vi-mode symbol ❮" (
+@test "_pure_get_prompt_symbol: get default symbol ❯ when key binding is default" (
     set pure_reverse_prompt_symbol_in_vimode true
-    set pure_symbol_reverse_prompt '❮'
-    
+    set fish_bind_mode 'insert'
+    set fish_key_bindings 'fish_default_key_bindings'
+
+    _pure_get_prompt_symbol
+) = '❯'
+
+@test "_pure_get_prompt_symbol: get default symbol ❯ when bind mode is default" (
+    set pure_reverse_prompt_symbol_in_vimode true
+    set fish_key_bindings 'fish_default_key_bindings'
+    set fish_bind_mode 'default'
+
+    _pure_get_prompt_symbol
+) = '❯'
+
+@test "_pure_get_prompt_symbol: get reverse symbol ❮ when VI key binding and not in insert mode" (
+    set pure_reverse_prompt_symbol_in_vimode true
+    set fish_bind_mode 'default'
+    set fish_key_bindings 'fish_vi_key_bindings'
+
     _pure_get_prompt_symbol
 ) = '❮'

--- a/tests/_pure_prompt.test.fish
+++ b/tests/_pure_prompt.test.fish
@@ -2,6 +2,7 @@ source $current_dirname/../functions/_pure_prompt.fish
 source $current_dirname/../functions/_pure_prompt_virtualenv.fish
 source $current_dirname/../functions/_pure_prompt_vimode.fish
 source $current_dirname/../functions/_pure_prompt_symbol.fish
+source $current_dirname/../functions/_pure_get_prompt_symbol.fish
 source $current_dirname/../functions/_pure_print_prompt.fish
 source $current_dirname/../functions/_pure_string_width.fish
 

--- a/tests/_pure_prompt_symbol.test.fish
+++ b/tests/_pure_prompt_symbol.test.fish
@@ -1,4 +1,5 @@
 source $current_dirname/../functions/_pure_prompt_symbol.fish
+source $current_dirname/../functions/_pure_get_prompt_symbol.fish
 
 set --local empty ''
 set --local fail 1

--- a/tests/_pure_prompt_symbol.test.fish
+++ b/tests/_pure_prompt_symbol.test.fish
@@ -1,5 +1,5 @@
-source $current_dirname/../functions/_pure_prompt_symbol.fish
 source $current_dirname/../functions/_pure_get_prompt_symbol.fish
+source $current_dirname/../functions/_pure_prompt_symbol.fish
 
 set --local empty ''
 set --local fail 1


### PR DESCRIPTION
**related:** #139 

---

This PR changes the default behavior of the prompt in vi mode, as discussed in #139.

Previously, the prompt retained the fish shell's default mode indicator: it would print `[I]`, `[N]`, or `[V]` to indicate whether the user was in insert, normal, or visual mode.

After this commit, the prompt will flip to `❮` whenever the user is not in insert mode.  This matches the behavior of the zsh version of Pure.

The user can restore the prior functionality by setting the `pure_reverse_prompt_symbol_in_vimode` variable to `false` in their _conf.d/pure.fish_ file.