### PR TITLE
Fix git pending commits

### DIFF
--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -1,4 +1,4 @@
-set --universal pure_version 2.0.0 # used for bug report
+set --universal pure_version 2.0.1 # used for bug report
 
 # Base colors
 _pure_set_default pure_color_primary (set_color blue)

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -1,4 +1,4 @@
-set --universal pure_version 2.0.1 # used for bug report
+set --universal pure_version 2.0.2 # used for bug report
 
 # Base colors
 _pure_set_default pure_color_primary (set_color blue)

--- a/functions/_pure_prompt_git.fish
+++ b/functions/_pure_prompt_git.fish
@@ -5,7 +5,7 @@ function _pure_prompt_git \
 
     if test -n "$is_git_repository"
         set --local git_prompt (_pure_prompt_git_branch)(_pure_prompt_git_dirty)
-        set --local git_pending_commits (git_pending_commits)
+        set --local git_pending_commits (_pure_prompt_git_pending_commits)
 
         if test (_pure_string_width $git_pending_commits) -ne 0
             set git_prompt $git_prompt $git_pending_commits

--- a/tests/_pure_prompt_git.test.fish
+++ b/tests/_pure_prompt_git.test.fish
@@ -17,7 +17,7 @@ end
 
 @test "_pure_prompt_git: ignores directory that are not git repository" (
     function _pure_prompt_git_dirty; echo $empty; end
-    function git_pending_commits; echo $empty; end
+    function _pure_prompt_git_pending_commits; echo $empty; end
 
     _pure_prompt_git
 ) $status -eq $succeed
@@ -25,7 +25,7 @@ end
 @test "_pure_prompt_git: activates on git repository" (
     git init --quiet
     function _pure_prompt_git_dirty; echo $empty; end
-    function git_pending_commits; echo $empty; end
+    function _pure_prompt_git_pending_commits; echo $empty; end
 
     set pure_color_git_branch $empty
     set pure_color_git_dirty $empty
@@ -37,7 +37,7 @@ end
 @test "_pure_prompt_git: activates on dirty repository" (
     git init --quiet
     function _pure_prompt_git_dirty; echo '*'; end
-    function git_pending_commits; echo $empty; end
+    function _pure_prompt_git_pending_commits; echo $empty; end
 
     set pure_color_git_branch $empty
     set pure_color_git_dirty $empty
@@ -49,7 +49,7 @@ end
 @test "_pure_prompt_git: activates on repository with upstream changes" (
     git init --quiet
     function _pure_prompt_git_dirty; echo $empty; end
-    function git_pending_commits; echo 'v'; end
+    function _pure_prompt_git_pending_commits; echo 'v'; end
 
     set pure_color_git_branch $empty
     set pure_color_git_dirty $empty

--- a/tools/installer.fish
+++ b/tools/installer.fish
@@ -27,7 +27,7 @@ function pure::fetch_source
     set --local package "https://github.com/rafaelrinaldi/pure/archive/master.tar.gz"
     mkdir --parents $PURE_INSTALL_DIR
 
-    command curl --show-error --location "$package" | command tar -xzf- -C $PURE_INSTALL_DIR; or begin;
+    command curl --show-error --location "$package" | command tar -xzf- -C $PURE_INSTALL_DIR --strip-components=1; or begin;
         printf "%sError: fetching Pure sources failed%s" "$color_error" "$color_normal"
         return 1
     end


### PR DESCRIPTION
fixes #144

---

* fix wrongly named method call `git_pending_commits` to `_pure_git_pending_commits`
  * bump `pure_version` number to `2.0.1`
* fix manual install method by extracting archive directly in `$HOME/.config/fish/functions/theme-pure/` (not in sub-directory). This will be available after the merge, hence the CI failing.
  * bump `pure_version` number to `2.0.2`