### PR TITLE
fix vi mode indicator when using fish_hybrid_key_bindings

### DIFF
--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -1,4 +1,4 @@
-set --universal pure_version 2.1.0 # used for bug report
+set --universal pure_version 2.1.1 # used for bug report
 
 # Base colors
 _pure_set_default pure_color_primary (set_color blue)

--- a/functions/_pure_get_prompt_symbol.fish
+++ b/functions/_pure_get_prompt_symbol.fish
@@ -3,7 +3,7 @@ function _pure_get_prompt_symbol \
     --argument-names exit_code
 
     set --local prompt_symbol $pure_symbol_prompt
-    set --local is_vi_mode (string match fish_{vi,hybrid}_key_bindings $fish_key_bindings)
+    set --local is_vi_mode (string match -r "fish_(vi|hybrid)_key_bindings" $fish_key_bindings)
     if test -n "$is_vi_mode" \
             -a "$pure_reverse_prompt_symbol_in_vimode" = true \
             -a "$fish_bind_mode" != "insert"

--- a/tests/_pure_get_prompt_symbol.test.fish
+++ b/tests/_pure_get_prompt_symbol.test.fish
@@ -39,3 +39,11 @@ end
 
     _pure_get_prompt_symbol
 ) = '❮'
+
+@test "_pure_get_prompt_symbol: get reverse symbol ❮ when hybrid key binding and not in insert mode" (
+    set pure_reverse_prompt_symbol_in_vimode true
+    set fish_bind_mode 'default'
+    set fish_key_bindings 'fish_hybrid_key_bindings'
+
+    _pure_get_prompt_symbol
+) = '❮'


### PR DESCRIPTION
**related:** #148 

---

The new vi mode indicator didn't work when using hybrid bindings. The pattern in `_pure_get_prompt_symbol.fish` only matched "fish_vi_key_bindings". With this patch regex matching is used to match vi and hybrid bindings.