### PR TITLE
Fix reverse prompt symbol in hybrid mode

### DIFF
--- a/functions/_pure_get_prompt_symbol.fish
+++ b/functions/_pure_get_prompt_symbol.fish
@@ -3,7 +3,7 @@ function _pure_get_prompt_symbol \
     --argument-names exit_code
 
     set --local prompt_symbol $pure_symbol_prompt
-    set --local is_vi_mode (string match fish_{vi,hybrid}_key_bindings $fish_key_bindings)
+    set --local is_vi_mode (string match -r 'fish_(vi|hybrid)_key_bindings' $fish_key_bindings)
     if test -n "$is_vi_mode" \
             -a "$pure_reverse_prompt_symbol_in_vimode" = true \
             -a "$fish_bind_mode" != "insert"


### PR DESCRIPTION
fish_hybrid_key_bindings was not being matched with fish_{vi,hybrid}_key_bindings causing the reverse prompt symbol to not work in command mode when using fish_hybrid_key_bindings