### PR TITLE
Fix manual install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ MIT © [Rafael Rinaldi](http://rinaldi.io)
 [travis-badge]: https://travis-ci.org/rafaelrinaldi/pure.svg?branch=master
 [fish-2.5]: https://img.shields.io/badge/fish-v2.5.0-007EC7.svg?style=flat-square "Support Fish 2.5"
 [fish-2.6]: https://img.shields.io/badge/fish-v2.6.0-007EC7.svg?style=flat-square "Support Fish 2.6"
-[fish-2.7.1]: https://img.shields.io/badge/fish-v2.7.1.0-007EC7.svg?style=flat-square "Support Fish 2.7.1"
-[fish-3.0.0]: https://img.shields.io/badge/fish-v3.0.0.0-007EC7.svg?style=flat-square "Support Fish 3.0.0"
+[fish-2.7.1]: https://img.shields.io/badge/fish-v2.7.1-007EC7.svg?style=flat-square "Support Fish 2.7.1"
+[fish-3.0.0]: https://img.shields.io/badge/fish-v3.0.0-007EC7.svg?style=flat-square "Support Fish 3.0.0"
 [changelog-2.5]: https://github.com/fish-shell/fish-shell/releases/tag/2.5.0 "Changelog Fish 2.5"
 [changelog-2.6]: https://github.com/fish-shell/fish-shell/releases/tag/2.6.0 "Changelog Fish 2.6"
 [changelog-2.7.1]: https://github.com/fish-shell/fish-shell/releases/tag/2.7.1 "Changelog Fish 2.7.1"

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -1,4 +1,4 @@
-set --universal pure_version 2.1.3 # used for bug report
+set --universal pure_version 2.1.4 # used for bug report
 
 # Base colors
 _pure_set_default pure_color_primary (set_color blue)

--- a/tests/installation-methods.test.fish
+++ b/tests/installation-methods.test.fish
@@ -23,11 +23,21 @@ function setup
 end
 
 if test $USER = 'nemo'
-    @test "installation methods: manually" (
-        curl git.io/pure-fish --output /tmp/pure_installer.fish --location --silent >/dev/null
-        and source /tmp/pure_installer.fish
+    @test "installation methods: manually (with unpublished installer)" (
+        source tools/installer.fish
 
         and install_pure >/dev/null
+        source $PURE_INSTALL_DIR/conf.d/*
+
+        fish -c 'fish_prompt | grep -c "❯"' 
+    ) = 1
+end
+
+if test $USER = 'nemo'
+    @test "installation methods: manually (with published installer)" (
+        curl git.io/pure-fish --output /tmp/installer.fish --location --silent
+        and source /tmp/installer.fish
+        and install_pure
 
         fish -c 'fish_prompt | grep -c "❯"' 
     ) = 1
@@ -36,6 +46,7 @@ end
 if test $USER = 'nemo'
     @test "installation methods: with fisher" (
         fisher add rafaelrinaldi/pure >/dev/null
+
         fish -c 'fish_prompt | grep -c "❯"' 
     ) = 1
 end

--- a/tests/installation-methods.test.fish
+++ b/tests/installation-methods.test.fish
@@ -1,16 +1,25 @@
-function setup
-    cd $HOME
-    for file in $HOME/.config/fish/functions/fish_*.fish;
-        rm $file
+function rm_pure_files
+    for file in $HOME/.config/fish/functions/_pure*.fish
+        rm --recursive --force "$file"
     end
-    echo 'function fish_prompt; end' > $HOME/.config/fish/functions/fish_prompt.fish
+    for file in $HOME/.config/fish/conf.d/*pure*
+        rm --recursive --force "$file"
+    end
     rm --recursive --force $HOME/.config/fish/functions/theme-pure
-    echo '' > $HOME/.config/fish/config.fish
 end
 
-function teardown
-    rm --force $HOME/.config/fish/functions/fish_prompt.fish
-    echo 'function fish_prompt; end' > $HOME/.config/fish/functions/fish_prompt.fish
+function rm_fish_prompt_files
+    for file in $HOME/.config/fish/functions/fish_*.fish
+        rm --recursive --force "$file"
+    end
+end
+
+function setup
+    if test $USER = 'nemo'
+        rm_pure_files
+        rm_fish_prompt_files
+        echo '' > $HOME/.config/fish/config.fish
+    end
 end
 
 if test $USER = 'nemo'
@@ -18,7 +27,6 @@ if test $USER = 'nemo'
         curl git.io/pure-fish --output /tmp/pure_installer.fish --location --silent >/dev/null
         and source /tmp/pure_installer.fish
 
-        rm --recursive --force $HOME/.config/fish/functions/theme-pure        
         and install_pure >/dev/null
 
         fish -c 'fish_prompt | grep -c "❯"' 

--- a/tests/installation-methods.test.fish
+++ b/tests/installation-methods.test.fish
@@ -57,7 +57,13 @@ if test $USER = 'nemo'
 
         curl -L https://get.oh-my.fish > install
         and fish install --noninteractive >/dev/null
-        and fish -c "omf install pure; fish_prompt" | grep -c '❯' 
+
+        set --global OMF_PURE_PATH $HOME/.local/share/omf/themes/pure
+        fish -c "omf install pure; \
+                ln -sf $OMF_PURE_PATH/fish_*.fish $HOME/.config/fish/functions/; \
+                ln -sf $OMF_PURE_PATH/functions/*.fish $HOME/.config/fish/functions/; \
+                ln -sf $OMF_PURE_PATH/conf.d/* $HOME/.config/fish/conf.d/" > /dev/null
+        fish -c "fish_prompt" | grep -c '❯' 
     ) = 1
 end
 

--- a/tests/pure_tools_installer.test.fish
+++ b/tests/pure_tools_installer.test.fish
@@ -9,22 +9,22 @@ function teardown
 end
 
 @test "installer: pass argument to set $FISH_CONFIG_DIR" (
-    pure::set_fish_config_path "/custom/config/path" >/dev/null
+    pure_set_fish_config_path "/custom/config/path" >/dev/null
     echo "$FISH_CONFIG_DIR"
 ) = "/custom/config/path"
 
 @test 'installer: set $FISH_CONFIG_DIR to default value' (
-    pure::set_fish_config_path >/dev/null
+    pure_set_fish_config_path >/dev/null
     echo "$FISH_CONFIG_DIR"
 ) = "$HOME/.config/fish"
 
 @test "installer: pass arguments to set $PURE_INSTALL_DIR" (
-    pure::set_pure_install_path "/custom/config/path" "/custom/theme/path" >/dev/null
+    pure_set_pure_install_path "/custom/config/path" "/custom/theme/path" >/dev/null
     echo "$PURE_INSTALL_DIR"
 ) = "/custom/theme/path"
 
 @test 'installer: set $PURE_INSTALL_DIR to default value' (
-    pure::set_pure_install_path >/dev/null
+    pure_set_pure_install_path >/dev/null
     echo $PURE_INSTALL_DIR
 ) = "$FISH_CONFIG_DIR/functions/theme-pure"
 
@@ -32,7 +32,7 @@ end
     touch $FISH_CONFIG_DIR/functions/fish_prompt.fish
     rm -f $FISH_CONFIG_DIR/functions/fish_prompt.fish.ignore
 
-    pure::backup_existing_theme >/dev/null
+    pure_backup_existing_theme >/dev/null
 ) -e "$FISH_CONFIG_DIR/functions/fish_prompt.fish.ignore"
 
 @test "installer: inject autoloading in config" (
@@ -40,7 +40,7 @@ end
     mkdir -p $PURE_INSTALL_DIR/conf.d/
     touch $PURE_INSTALL_DIR/conf.d/pure.fish
 
-    pure::enable_autoloading >/dev/null
+    pure_enable_autoloading >/dev/null
     grep -q 'fish_function_path' $FISH_CONFIG_DIR/config.fish
 ) $status -eq 0
 
@@ -51,15 +51,15 @@ end
     mkdir -p $PURE_INSTALL_DIR; \
         and touch $PURE_INSTALL_DIR/fish_prompt.fish  # stub
 
-    pure::enable_autoloading >/dev/null
+    pure_enable_autoloading >/dev/null
 
     grep -c "pure.fish" $FISH_CONFIG_DIR/config.fish
 ) = 1
 
 @test "installer: app path to theme's functions" (
-    pure::enable_autoloading >/dev/null
+    pure_enable_autoloading >/dev/null
 
-    pure::enable_theme >/dev/null
+    pure_enable_theme >/dev/null
 
     [ "$fish_function_path[1]" = "$PURE_INSTALL_DIR/functions/" ];
 ) $status -eq 0
@@ -67,7 +67,7 @@ end
 @test "installer: load theme file" (
     echo 'set --global _pure_fresh_session true' > $FISH_CONFIG_DIR/config.fish
 
-    pure::enable_theme >/dev/null
+    pure_enable_theme >/dev/null
 
     [ "$_pure_fresh_session" = true ]
 ) $status -eq 0

--- a/tests/pure_tools_installer.test.fish
+++ b/tests/pure_tools_installer.test.fish
@@ -44,6 +44,7 @@ end
     grep -q 'fish_function_path' $FISH_CONFIG_DIR/config.fish
 ) $status -eq 0
 
+
 @test "installer: activate prompt" (
     set --local active_prompt $FISH_CONFIG_DIR/functions/fish_prompt.fish
     rm -f "$active_prompt"
@@ -52,8 +53,8 @@ end
 
     pure::enable_autoloading >/dev/null
 
-    [ -r "$active_prompt" -a -L "$active_prompt" ]  # a readable symlink
-) $status -eq 0
+    grep -c "pure.fish" $FISH_CONFIG_DIR/config.fish
+) = 1
 
 @test "installer: app path to theme's functions" (
     pure::enable_autoloading >/dev/null
@@ -71,3 +72,15 @@ end
     [ "$_pure_fresh_session" = true ]
 ) $status -eq 0
 
+if test $USER = 'nemo'
+    @test "installer: link configuration and functions to fish config directory" (
+        rm --force --recursive $FISH_CONFIG_DIR/{conf.d,functions}
+        mkdir -p $FISH_CONFIG_DIR/{conf.d,functions}
+        set PURE_INSTALL_DIR /tmp/.pure/
+
+        pure_symlinks_assets >/dev/null
+
+        set --local active_prompt $FISH_CONFIG_DIR/functions/fish_prompt.fish
+        [ -r "$active_prompt" -a -L "$active_prompt" ]  # a readable symlink
+    ) $status -eq 0
+end

--- a/tools/installer.fish
+++ b/tools/installer.fish
@@ -3,7 +3,7 @@ set color_error (set_color --bold red)
 set color_white (set_color white)
 set color_normal (set_color normal)
 
-function pure::set_fish_config_path
+function pure_set_fish_config_path
     printf "\tSet environment variable: %s\n" "\$FISH_CONFIG_DIR"
     if test (count $argv) -ge 1
         set -gx FISH_CONFIG_DIR $argv[1]
@@ -12,7 +12,7 @@ function pure::set_fish_config_path
     end
 end
 
-function pure::set_pure_install_path
+function pure_set_pure_install_path
     printf "\tSet environment variable: %s\n" "\$PURE_INSTALL_DIR"
     if test (count $argv) -ge 2
         set -gx PURE_INSTALL_DIR $argv[2]
@@ -21,7 +21,7 @@ function pure::set_pure_install_path
     end
 end
 
-function pure::fetch_source
+function pure_fetch_source
     printf "\tFetching theme's source"
 
     set --local package "https://github.com/rafaelrinaldi/pure/archive/master.tar.gz"
@@ -33,18 +33,18 @@ function pure::fetch_source
     end
 end
 
-function pure::backup_existing_theme
+function pure_backup_existing_theme
     printf "\tBackuping existing theme"
     set --local old_prompt $FISH_CONFIG_DIR/functions/fish_prompt.fish
     set --local backup_prompt $old_prompt.ignore
     
     if test -f "$old_prompt"
-        mv "$old_prompt" "$backup_prompt"; pure::exit_symbol $status
+        mv "$old_prompt" "$backup_prompt"; pure_exit_symbol $status
         printf "\tPrevious config saved to: %s%s%s." "$color_white" "$backup_prompt" "$color_normal"
     end
 end
 
-function pure::enable_autoloading
+function pure_enable_autoloading
     printf "\tEnabling autoloading for pure's functions on shell init"
     touch "$FISH_CONFIG_DIR/config.fish"
     if not grep -q "pure.fish" $FISH_CONFIG_DIR/config.fish
@@ -61,46 +61,46 @@ function pure_symlinks_assets
     ln -sf $PURE_INSTALL_DIR/conf.d/* $FISH_CONFIG_DIR/conf.d/
 end
 
-function pure::enable_theme
+function pure_enable_theme
     printf "\tEnabling theme"
     set fish_function_path $PURE_INSTALL_DIR/functions/ $fish_function_path
     source $FISH_CONFIG_DIR/config.fish
 end
 
-function pure::clean_after_install
+function pure_clean_after_install
     printf "\tCleaning after install"
-    functions --erase pure::set_fish_config_dir
-    functions --erase pure::set_pure_install_dir
-    functions --erase pure::fetch_source
-    functions --erase pure::backup_existing_theme
-    functions --erase pure::enable_autoloading
+    functions --erase pure_set_fish_config_dir
+    functions --erase pure_set_pure_install_dir
+    functions --erase pure_fetch_source
+    functions --erase pure_backup_existing_theme
+    functions --erase pure_enable_autoloading
     functions --erase pure_symlinks_assets
-    functions --erase pure::enable_theme
+    functions --erase pure_enable_theme
 end
 
-function pure::success
+function pure_success
     echo $color_success "✔" $color_normal
 end
-function pure::error
+function pure_error
     echo $color_error "✖" $color_normal
 end
 
-function pure::exit_symbol
+function pure_exit_symbol
     if test $argv[1] -eq 0
-        pure::success
+        pure_success
     else
-        pure::error
+        pure_error
     end
 end
 
 function install_pure
     printf "Installing Pure theme\n"
-    pure::set_fish_config_path $argv
-    pure::set_pure_install_path $argv
-    pure::fetch_source; pure::exit_symbol $status
-    pure::backup_existing_theme; pure::exit_symbol $status
-    pure::enable_autoloading; pure::exit_symbol $status
-    pure_symlinks_assets; pure::exit_symbol $status
-    pure::enable_theme; pure::exit_symbol $status
-    pure::clean_after_install; pure::exit_symbol $status
+    pure_set_fish_config_path $argv
+    pure_set_pure_install_path $argv
+    pure_fetch_source; pure_exit_symbol $status
+    pure_backup_existing_theme; pure_exit_symbol $status
+    pure_enable_autoloading; pure_exit_symbol $status
+    pure_symlinks_assets; pure_exit_symbol $status
+    pure_enable_theme; pure_exit_symbol $status
+    pure_clean_after_install; pure_exit_symbol $status
 end

--- a/tools/installer.fish
+++ b/tools/installer.fish
@@ -39,8 +39,8 @@ function pure::backup_existing_theme
     set --local backup_prompt $old_prompt.ignore
     
     if test -f "$old_prompt"
-        mv "$old_prompt" "$backup_prompt"
-        printf "\t\tPrevious config saved to: %s%s%s." "$color_white" "$backup_prompt" "$color_normal"
+        mv "$old_prompt" "$backup_prompt"; pure::exit_symbol $status
+        printf "\tPrevious config saved to: %s%s%s." "$color_white" "$backup_prompt" "$color_normal"
     end
 end
 

--- a/tools/installer.fish
+++ b/tools/installer.fish
@@ -52,6 +52,10 @@ function pure::enable_autoloading
         echo "set fish_function_path $PURE_INSTALL_DIR/functions/" '$fish_function_path' >> $FISH_CONFIG_DIR/config.fish
         echo "source $PURE_INSTALL_DIR/conf.d/pure.fish" >> $FISH_CONFIG_DIR/config.fish
     end
+end
+
+function pure_symlinks_assets
+    printf "\tLink pure's configuration and functions to fish config directory"
     ln -sf $PURE_INSTALL_DIR/fish_*.fish $FISH_CONFIG_DIR/functions/
     ln -sf $PURE_INSTALL_DIR/functions/*.fish $FISH_CONFIG_DIR/functions/
     ln -sf $PURE_INSTALL_DIR/conf.d/* $FISH_CONFIG_DIR/conf.d/
@@ -70,6 +74,7 @@ function pure::clean_after_install
     functions --erase pure::fetch_source
     functions --erase pure::backup_existing_theme
     functions --erase pure::enable_autoloading
+    functions --erase pure_symlinks_assets
     functions --erase pure::enable_theme
 end
 
@@ -95,6 +100,7 @@ function install_pure
     pure::fetch_source; pure::exit_symbol $status
     pure::backup_existing_theme; pure::exit_symbol $status
     pure::enable_autoloading; pure::exit_symbol $status
+    pure_symlinks_assets; pure::exit_symbol $status
     pure::enable_theme; pure::exit_symbol $status
     pure::clean_after_install; pure::exit_symbol $status
 end

--- a/tools/installer.fish
+++ b/tools/installer.fish
@@ -52,7 +52,9 @@ function pure::enable_autoloading
         echo "set fish_function_path $PURE_INSTALL_DIR/functions/" '$fish_function_path' >> $FISH_CONFIG_DIR/config.fish
         echo "source $PURE_INSTALL_DIR/conf.d/pure.fish" >> $FISH_CONFIG_DIR/config.fish
     end
-    ln -sf $PURE_INSTALL_DIR/fish_prompt.fish $FISH_CONFIG_DIR/functions/
+    ln -sf $PURE_INSTALL_DIR/fish_*.fish $FISH_CONFIG_DIR/functions/
+    ln -sf $PURE_INSTALL_DIR/functions/*.fish $FISH_CONFIG_DIR/functions/
+    ln -sf $PURE_INSTALL_DIR/conf.d/* $FISH_CONFIG_DIR/conf.d/
 end
 
 function pure::enable_theme


### PR DESCRIPTION
* fixes #161 by copying config and functions to $FISH_CONFIG_DIR/ during manual install 
* fixes `OMF` test that was also broken https://github.com/oh-my-fish/oh-my-fish/issues/695
* correct typo in badge for supported version

### Failing test?

One test should fell as it uses the old version of the installer script:

> installation methods: manually (with published installer)

Be sure that the one that use the PR code passes:

> installation methods: manually (with unpublished installer)