### PR TITLE
Scaffold fish directory during install & Improve contributor doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,3 +118,17 @@ $pure_enable_git_async = false
 ```fish
 $pure_threshold_command_duration
 ```
+
+## How to develop?
+
+We provide a [makefile](makefile) and a [Dockerfile](tools/pure-on-fish.Dockerfile) to help you work on `pure`.
+
+### :checkered_flag: Build container
+
+Specify the [`fish` version](https://github.com/oh-my-fish/dockerfiles/tree/master/fish) you want to work with using `FISH_VERSION` argument:
+
+    make build-pure-on FISH_VERSION=3.0.0
+
+### :heavy_check_mark: Run Tests
+
+    make dev-pure-on FISH_VERSION=3.0.0 CMD="fishtape tests/*.test.fish"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-## Code of Conduct
+# Code of Conduct
 
 * Be kind to others ;
 * Critic code not people.
@@ -8,6 +8,7 @@
 Note, we follow [semver](https://semver.org/).
 
 Todo upon release:
+
 * [ ] updated `pure_version` (in [_conf.d/pure.fish_](conf.d/pure.fish)) ;
 * [ ] create a commit only containing above edit ;
 * [ ] create a git tag for said commit.
@@ -42,7 +43,7 @@ Todo upon release:
 * filename: `my_tool.fish`
 * test file: `my_tool.test.fish`
 
-## Global Variable
+### Global Variable
 
 * Public settings' default values are placed in [_conf.d/pure.fish_](conf.d/pure.fish)
 * Private settings and anything else `pure` needs to do on init are placed in [_conf.d/__pure_init.fish_](conf.d/_pure_init.fish).
@@ -51,7 +52,7 @@ Todo upon release:
 
 > Base colors should follow `$pure_color_<meaning>` pattern (cf. [bootstrap naming](https://getbootstrap.com/docs/4.1/utilities/colors/)).
 
-##### Example
+#### Example
 
 ```fish
 $pure_color_info     # cyan
@@ -75,7 +76,7 @@ $pure_color_muted    # gray
 > | color  | `$pure_color_<feature>`  |
 > | symbol | `$pure_symbol_<feature>` |
 
-##### Example
+#### Example
 
 ```fish
 $pure_enable_git_status
@@ -89,15 +90,16 @@ $pure_symbol_git_unpushed_commits
 $pure_color_git_unpulled_commits
 ```
 
-## Feature Flag's Variable
+### Feature Flag's Variable
 
 > Name should follow `$pure_<verb>_<feature>` pattern, where:
+> 
   > * `verb` describe the action triggered by the feature (_i.e._ `separate`, `begin`, `show`, etc.) ;
   > * `feature` descibre the _what_ of the feature (_i.e._ `prompt_on_error`, `with_current_directory`, `git_status`, etc.).
 
 > Value should be **a boolean**.
   
-##### Example
+#### Example
 
 ```fish
 $pure_begin_prompt_with_current_directory = true
@@ -107,11 +109,11 @@ $pure_begin_prompt_with_current_directory = true
 $pure_enable_git_async = false
 ```
 
-## Avoid abbreviation
+### Avoid abbreviation
 
 > Use complete word over abbreviation.
 
-##### Example
+#### Example
 
 ```fish
 $pure_threshold_command_duration

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,6 @@
-# Code of Conduct
+# Contribution Guide
+
+## Code of Conduct
 
 * Be kind to others ;
 * Critic code not people.
@@ -9,9 +11,9 @@ Note, we follow [semver](https://semver.org/).
 
 Todo upon release:
 
-* [ ] updated `pure_version` (in [_conf.d/pure.fish_](conf.d/pure.fish)) ;
-* [ ] create a commit only containing above edit ;
-* [ ] create a git tag for said commit.
+* [ ] Updated `pure_version` (in [_conf.d/pure.fish_](conf.d/pure.fish)) ;
+* [ ] Create a commit only containing above edit ;
+* [ ] Create a git tag for said commit.
 
 ## Code Conventions for `pure`
 
@@ -22,26 +24,26 @@ Todo upon release:
 
 > Namespace your item with the prefix `pure_`.
 
-* variable: `pure_my_variable`
-* function: `pure_my_public_function`
-* filename: `pure_my_public_file.fish`
-* test file: `pure_my_public_file.test.fish`
+* Variable: `pure_my_variable`
+* Function: `pure_my_public_function`
+* Filename: `pure_my_public_file.fish`
+* Test file: `pure_my_public_file.test.fish`
 
 ### Naming Private Item
 
 > Namespace your item with the prefix `_pure_` (begin with a single underscore).
 
-* variable: `_pure_my_variable`
-* function: `_pure_my_private_function`
-* filename: `_pure_my_private_file.fish`
-* test file: `_pure_my_private_file.test.fish`
+* Variable: `_pure_my_variable`
+* Function: `_pure_my_private_function`
+* Filename: `_pure_my_private_file.fish`
+* Test file: `_pure_my_private_file.test.fish`
 
 ### Local and Tools
 
 > No need to use namespace when your variable variable is declare locally (`set --local`) or your file/test file is related to tooling (_installer.fish_, testing package managers install).
 
-* filename: `my_tool.fish`
-* test file: `my_tool.test.fish`
+* Filename: `my_tool.fish`
+* Test file: `my_tool.test.fish`
 
 ### Global Variable
 
@@ -67,7 +69,6 @@ $pure_color_muted    # gray
 ### Feature's Variables
 
 > Each feature should have a dedicated variables to allow customization.
-
 > Feature's variables (flag, symbol, color) should use `$pure_<type>_<feature>` naming pattern:
 >
 > | Role   | Name pattern             |
@@ -93,10 +94,9 @@ $pure_color_git_unpulled_commits
 ### Feature Flag's Variable
 
 > Name should follow `$pure_<verb>_<feature>` pattern, where:
-> 
+>
   > * `verb` describe the action triggered by the feature (_i.e._ `separate`, `begin`, `show`, etc.) ;
   > * `feature` descibre the _what_ of the feature (_i.e._ `prompt_on_error`, `with_current_directory`, `git_status`, etc.).
-
 > Value should be **a boolean**.
   
 #### Example
@@ -118,17 +118,3 @@ $pure_enable_git_async = false
 ```fish
 $pure_threshold_command_duration
 ```
-
-## How to develop?
-
-We provide a [makefile](makefile) and a [Dockerfile](tools/pure-on-fish.Dockerfile) to help you work on `pure`.
-
-### :checkered_flag: Build container
-
-Specify the [`fish` version](https://github.com/oh-my-fish/dockerfiles/tree/master/fish) you want to work with using `FISH_VERSION` argument:
-
-    make build-pure-on FISH_VERSION=3.0.0
-
-### :heavy_check_mark: Run Tests
-
-    make dev-pure-on FISH_VERSION=3.0.0 CMD="fishtape tests/*.test.fish"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <a href="screenshot-light.png" target=blank><img width=440 src=https://i.imgur.com/qJdonqo.png alt="Pure with light colorscheme"></a>
 </div>
 
-## Install
+## :rocket: Install
 
 **:warning: requirements**: fish `≥2.5`
 
@@ -68,19 +68,15 @@ source /tmp/pure_installer.fish; and install_pure
 - Print current working directory at the beginning of prompt
 - Can check for new release on start
 
-## Configuration
+## :paintbrush: Configuration
 
-You can tweak pretty much everything in `pure` by overriding defaults with global variables in your `config.fish` file:
+You can tweak `pure` behavior by changing [universal variables](https://fishshell.com/docs/current/tutorial.html#tut_universal) directly in the terminal:
 
-```
-set -g pure_symbol_prompt ">"
-```
+    set --universal pure_show_system_time true
 
-or by changing [universal variables](https://fishshell.com/docs/current/tutorial.html#tut_universal) directly in the terminal (which will be preserved between all `fish` sessions on the computer):
+or changing the defaults in your `config.fish`:
 
-```
-set -U pure_symbol_prompt ">"
-```
+    _pure_set_default pure_show_system_time true
 
 #### Prompt Symbol
 
@@ -105,7 +101,7 @@ set -U pure_symbol_prompt ">"
 | **`pure_separate_prompt_on_error`**            | `false` | Show last command [exit code as a separate character][exit-code].                               |
 | **`pure_threshold_command_duration`**          | `5`     | Show command duration when above this value (seconds).                                          |
 | **`pure_reverse_prompt_symbol_in_vimode`**     | `true`  | `true`: `❮` indicate a non-insert mode.<br/>`false`: indicate vi mode with `[I]`, `[N]`, `[V]`. |
-| **`pure_check_for_new_release false`**         | `false` | `true`: check repo for new release (on every shell start)                                       |
+| **`pure_check_for_new_release`**               | `false` | `true`: check repo for new release (on every shell start)                                       |
 
 #### Colors
 
@@ -135,18 +131,26 @@ Take a note on the absence of `$` sign before the second argument in this case. 
 | **`pure_color_warning`** | **`pure_color_command_duration`**                                                                                                                                                               | `yellow`  |
 | **`pure_color_dark`**    |                                                                                                                                                                                                 | `black`   |
 
-## Tests
+## :+1:  Contribute
 
-**requirements:** [`docker`](https://docs.docker.com/install/) (to run tests in isolation from user environment)
+**requirements:** [`docker`](https://docs.docker.com/install/) (isolate from your environment)
 
-    make build-pure-on FISH_VERSION=3.0.0  
-    make dev-pure-on   FISH_VERSION=3.0.0 CMD="fishtape tests/*.test.fish"
+Specify the [`FISH_VERSION`][fish-releases] you want, and the `CMD` executed by the container:
 
-## Maintainer
+    make build-pure-on FISH_VERSION=3.0.0
+    make dev-pure-on FISH_VERSION=3.0.0 CMD="fishtape tests/*.test.fish"
+
+## :man_technologist: Maintainer
 
 - [Édouard Lopez](https://github.com/edouard-lopez)
 
-## License
+## :clap: Thanks
+
+* [@andreiborisov](https://github.com/andreiborisov) for the [docker images][docker-images] ;
+* [@jorgebucaran](https://github.com/jorgebucaran/) for [fishtape](https://github.com/jorgebucaran/fishtape) ;
+* [@rafaelrinaldi](https://github.com/rafaelrinaldi/pure) for starting the project ;
+
+## :classical_building: License
 
 [MIT][MIT]
 
@@ -161,4 +165,6 @@ Take a note on the absence of `$` sign before the second argument in this case. 
 [changelog-2.7.1]: <https://github.com/fish-shell/fish-shell/releases/tag/2.7.1> "Changelog Fish 2.7.1"
 [changelog-3.0.0]: <https://github.com/fish-shell/fish-shell/releases/tag/3.0.0> "Changelog Fish 3.0.0"
 [exit-code]: <https://github.com/sindresorhus/pure/wiki#show-exit-code-of-last-command-as-a-separate-prompt-character> "See pure-zsh wiki"
+[fish-releases]: https://github.com/fish-shell/fish-shell/releases
+[docker-images]: https://github.com/andreiborisov/docker-fish/
 [MIT]: LICENSE.md

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 > ##### ✋ Psst! Migrating from v1.x to v2.x? We got you. Check our [**migration guide**](https://github.com/rafaelrinaldi/pure/releases/tag/v2.0.0) and happy upgrading
 
-# pure [![travis-badge]][travis-link] ![fish-2.5] ![fish-2.6] ![fish-2.7.1] ![fish-3.0.0]
+# pure [![github-ci-badge]][github-ci-link] ![fish-2.5] ![fish-2.6] ![fish-2.7.1] ![fish-3.0.0]
 
 > Pretty, minimal and fast Fish 🐟 prompt, ported from [`zsh`](https://github.com/sindresorhus/pure).
 
@@ -63,6 +63,10 @@ source /tmp/pure_installer.fish; and install_pure
 - Display `Python` _virtualenv_ when activated ;
 - Fine control over **colors** ;
 - Display `VI` mode and custom symbol for non-insert mode.
+- Show system time
+- Show number of running jobs
+- Print current working directory at the beginning of prompt
+- Can check for new release on start
 
 ## Configuration
 
@@ -95,12 +99,13 @@ set -U pure_symbol_prompt ">"
 | Option                                         | Default | Description                                                                                     |
 | :--------------------------------------------- | :------ | :---------------------------------------------------------------------------------------------- |
 | **`pure_enable_git`**                          | `true`  | Show info about Git repository.                                                                 |
-| **`pure_threshold_command_duration`**          | `5`     | Show command duration when above this value (seconds).                                          |
-| **`pure_separate_prompt_on_error`**            | `false` | Show last command [exit code as a separate character][exit-code].                               |
+| **`pure_show_jobs`**                           | `false` | Show Number of running jobs                                                                     |
+| **`pure_show_system_time`**                    | `false` | `true`: shows system time before the prompt symbol (as `%H:%M:%S`).                             |
 | **`pure_begin_prompt_with_current_directory`** | `true`  | `true`: _`pwd` `git`, `SSH`, duration_.<br/>`false`: _`SSH` `pwd` `git`, duration_.             |
+| **`pure_separate_prompt_on_error`**            | `false` | Show last command [exit code as a separate character][exit-code].                               |
+| **`pure_threshold_command_duration`**          | `5`     | Show command duration when above this value (seconds).                                          |
 | **`pure_reverse_prompt_symbol_in_vimode`**     | `true`  | `true`: `❮` indicate a non-insert mode.<br/>`false`: indicate vi mode with `[I]`, `[N]`, `[V]`. |
-| **`pure_check_for_new_release false`**         | `false`  | `true`: check repo for new release (on every shell start)
-| **`pure_show_system_time`** | `false` | `true`: shows system time before the prompt symbol (as `%H:%M:%S`).
+| **`pure_check_for_new_release false`**         | `false` | `true`: check repo for new release (on every shell start)                                       |
 
 #### Colors
 
@@ -155,14 +160,14 @@ MIT © [Rafael Rinaldi](http://rinaldi.io)
 <a href="https://buymeacoff.ee/rinaldi" title="Buy me a coffee">Buy me a ☕</a>
 </p>
 
-[travis-link]: https://travis-ci.org/rafaelrinaldi/pure "TravisCI"
-[travis-badge]: https://travis-ci.org/rafaelrinaldi/pure.svg?branch=master
-[fish-2.5]: https://img.shields.io/badge/fish-v2.5.0-007EC7.svg?style=flat-square "Support Fish 2.5"
-[fish-2.6]: https://img.shields.io/badge/fish-v2.6.0-007EC7.svg?style=flat-square "Support Fish 2.6"
-[fish-2.7.1]: https://img.shields.io/badge/fish-v2.7.1-007EC7.svg?style=flat-square "Support Fish 2.7.1"
-[fish-3.0.0]: https://img.shields.io/badge/fish-v3.0.0-007EC7.svg?style=flat-square "Support Fish 3.0.0"
-[changelog-2.5]: https://github.com/fish-shell/fish-shell/releases/tag/2.5.0 "Changelog Fish 2.5"
-[changelog-2.6]: https://github.com/fish-shell/fish-shell/releases/tag/2.6.0 "Changelog Fish 2.6"
-[changelog-2.7.1]: https://github.com/fish-shell/fish-shell/releases/tag/2.7.1 "Changelog Fish 2.7.1"
-[changelog-3.0.0]: https://github.com/fish-shell/fish-shell/releases/tag/3.0.0 "Changelog Fish 3.0.0"
-[exit-code]: https://github.com/sindresorhus/pure/wiki#show-exit-code-of-last-command-as-a-separate-prompt-character "See pure-zsh wiki"
+[github-ci-link]: <https://github.com/rafaelrinaldi/pure/actions> "Github CI"
+[github-ci-badge]: <https://github.com/rafaelrinaldi/pure/workflows/Run%20tests%20on%20CI/badge.svg>
+[fish-2.5]: <https://img.shields.io/badge/fish-v2.5.0-007EC7.svg?style=flat-square> "Support Fish 2.5"
+[fish-2.6]: <https://img.shields.io/badge/fish-v2.6.0-007EC7.svg?style=flat-square> "Support Fish 2.6"
+[fish-2.7.1]: <https://img.shields.io/badge/fish-v2.7.1-007EC7.svg?style=flat-square> "Support Fish 2.7.1"
+[fish-3.0.0]: <https://img.shields.io/badge/fish-v3.0.0-007EC7.svg?style=flat-square> "Support Fish 3.0.0"
+[changelog-2.5]: <https://github.com/fish-shell/fish-shell/releases/tag/2.5.0> "Changelog Fish 2.5"
+[changelog-2.6]: <https://github.com/fish-shell/fish-shell/releases/tag/2.6.0> "Changelog Fish 2.6"
+[changelog-2.7.1]: <https://github.com/fish-shell/fish-shell/releases/tag/2.7.1> "Changelog Fish 2.7.1"
+[changelog-3.0.0]: <https://github.com/fish-shell/fish-shell/releases/tag/3.0.0> "Changelog Fish 3.0.0"
+[exit-code]: <https://github.com/sindresorhus/pure/wiki#show-exit-code-of-last-command-as-a-separate-prompt-character> "See pure-zsh wiki"

--- a/README.md
+++ b/README.md
@@ -142,23 +142,13 @@ Take a note on the absence of `$` sign before the second argument in this case. 
     make build-pure-on FISH_VERSION=3.0.0  
     make dev-pure-on   FISH_VERSION=3.0.0 CMD="fishtape tests/*.test.fish"
 
-## Maintainers
+## Maintainer
 
-- [Rafael Rinaldi](https://github.com/rafaelrinaldi)
 - [Édouard Lopez](https://github.com/edouard-lopez)
-- [Andrei Borisov](https://github.com/schrodincat)
-
-Kudos to all our awesome [:yellow_heart: contributors :yellow_heart:](../..//graphs/contributors)
 
 ## License
 
-MIT © [Rafael Rinaldi](http://rinaldi.io)
-
----
-
-<p align="center">
-<a href="https://buymeacoff.ee/rinaldi" title="Buy me a coffee">Buy me a ☕</a>
-</p>
+[MIT][MIT]
 
 [github-ci-link]: <https://github.com/rafaelrinaldi/pure/actions> "Github CI"
 [github-ci-badge]: <https://github.com/rafaelrinaldi/pure/workflows/Run%20tests%20on%20CI/badge.svg>
@@ -171,3 +161,4 @@ MIT © [Rafael Rinaldi](http://rinaldi.io)
 [changelog-2.7.1]: <https://github.com/fish-shell/fish-shell/releases/tag/2.7.1> "Changelog Fish 2.7.1"
 [changelog-3.0.0]: <https://github.com/fish-shell/fish-shell/releases/tag/3.0.0> "Changelog Fish 3.0.0"
 [exit-code]: <https://github.com/sindresorhus/pure/wiki#show-exit-code-of-last-command-as-a-separate-prompt-character> "See pure-zsh wiki"
+[MIT]: LICENSE.md

--- a/README.md
+++ b/README.md
@@ -132,9 +132,10 @@ Take a note on the absence of `$` sign before the second argument in this case. 
 
 ## Tests
 
-**requirements:** [`fishtape`](https://github.com/fisherman/fishtape).
+**requirements:** [`docker`](https://docs.docker.com/install/) (to run tests in isolation from user environment)
 
-    fishtape tests/*.test.fish
+    make build-pure-on FISH_VERSION=3.0.0  
+    make dev-pure-on   FISH_VERSION=3.0.0 CMD="fishtape tests/*.test.fish"
 
 ## Maintainers
 

--- a/makefile
+++ b/makefile
@@ -21,23 +21,18 @@ build-pure-on:
 		--tag=pure-on-fish-${FISH_VERSION} \
 		./
 
+.PHONY: test-pure-on
+test-pure-on: export CMD=fishtape tests/*.test.fish  # can be overriden by user
+test-pure-on:
+	@$(MAKE) dev-pure-on  # ${CMD} is passed along
+
 .PHONY: dev-pure-on
 dev-pure-on: CMD?=fish
 dev-pure-on:
 	docker run \
 		--name run-pure-on-${FISH_VERSION} \
 		--rm \
-		--tty \
-		--volume=$$(pwd):/tmp/.pure/ \
-		pure-on-fish-${FISH_VERSION} "${CMD}"
-
-# Don't override COPY directive as `--volume` doesnt play nice with Travis
-.PHONY: test-pure-on
-test-pure-on: export CMD=fishtape tests/*.test.fish  # can be overriden by user
-test-pure-on:
-	docker run \
-		--name run-pure-on-${FISH_VERSION} \
-		--rm \
 		--interactive \
 		--tty \
+		--volume=$$(pwd):/tmp/.pure/ \
 		pure-on-fish-${FISH_VERSION} "${CMD}"

--- a/makefile
+++ b/makefile
@@ -39,6 +39,5 @@ test-pure-on:
 	docker run \
 		--name run-pure-on-${FISH_VERSION} \
 		--rm \
-		--interactive \
 		--tty \
 		pure-on-fish-${FISH_VERSION} "${CMD}"

--- a/makefile
+++ b/makefile
@@ -27,7 +27,6 @@ dev-pure-on:
 	docker run \
 		--name run-pure-on-${FISH_VERSION} \
 		--rm \
-		--interactive \
 		--tty \
 		--volume=$$(pwd):/tmp/.pure/ \
 		pure-on-fish-${FISH_VERSION} "${CMD}"

--- a/makefile
+++ b/makefile
@@ -21,11 +21,6 @@ build-pure-on:
 		--tag=pure-on-fish-${FISH_VERSION} \
 		./
 
-.PHONY: test-pure-on
-test-pure-on: export CMD=fishtape tests/*.test.fish  # can be overriden by user
-test-pure-on:
-	@$(MAKE) dev-pure-on  # ${CMD} is passed along
-
 .PHONY: dev-pure-on
 dev-pure-on: CMD?=fish
 dev-pure-on:
@@ -35,4 +30,15 @@ dev-pure-on:
 		--interactive \
 		--tty \
 		--volume=$$(pwd):/tmp/.pure/ \
+		pure-on-fish-${FISH_VERSION} "${CMD}"
+
+# Don't override COPY directive as `--volume` doesnt play nice with Travis
+.PHONY: test-pure-on
+test-pure-on: export CMD=fishtape tests/*.test.fish  # can be overriden by user
+test-pure-on:
+	docker run \
+		--name run-pure-on-${FISH_VERSION} \
+		--rm \
+		--interactive \
+		--tty \
 		pure-on-fish-${FISH_VERSION} "${CMD}"

--- a/makefile
+++ b/makefile
@@ -4,6 +4,7 @@
 SHELL := /bin/bash
 INTERACTIVE=true
 
+
 .PHONY: default
 default: usage
 usage:
@@ -21,14 +22,12 @@ build-pure-on:
 		./
 
 .PHONY: test-pure-on
+test-pure-on: export CMD=fishtape tests/*.test.fish  # can be overriden by user
 test-pure-on:
-	docker run \
-		--name test-pure-on-${FISH_VERSION} \
-		--rm \
-		--tty \
-		pure-on-fish-${FISH_VERSION}
+	@$(MAKE) dev-pure-on  # ${CMD} is passed along
 
 .PHONY: dev-pure-on
+dev-pure-on: CMD?=fish
 dev-pure-on:
 	docker run \
 		--name run-pure-on-${FISH_VERSION} \
@@ -36,4 +35,4 @@ dev-pure-on:
 		--interactive \
 		--tty \
 		--volume=$$(pwd):/tmp/.pure/ \
-		pure-on-fish-${FISH_VERSION}
+		pure-on-fish-${FISH_VERSION} "${CMD}"

--- a/tests/migration-to-2.0.0.test.fish
+++ b/tests/migration-to-2.0.0.test.fish
@@ -5,11 +5,11 @@ set --global DIRNAME $current_dirname
 
 
 function setup
-    cp $current_dirname/fixtures/{config.mock.fish,config.fish}
+    cp tests/fixtures/{config.mock.fish,config.fish}
 end
 
 function teardown
-    rm $current_dirname/fixtures/config.fish
+    rm tests/fixtures/config.fish
 end
 
 @test "migrate all variables" (

--- a/tests/pure_tools_installer.test.fish
+++ b/tests/pure_tools_installer.test.fish
@@ -212,3 +212,67 @@ if test $USER = 'nemo'
         fish -c "fish_prompt" | grep -c '>'
     ) = $IS_PRESENT
 end
+
+
+
+
+
+
+
+if test $USER = 'nemo'
+    @test "installation methods: manually (with unpublished installer)" (
+        source tools/installer.fish
+
+        and install_pure >/dev/null
+        source $PURE_INSTALL_DIR/conf.d/*
+
+        fish -c 'fish_prompt | grep -c "❯"'
+    ) = $succeed
+end
+
+# if test $USER = 'nemo'
+#     @test "installation methods: manually (with published installer)" (
+#         curl git.io/pure-fish --output /tmp/installer.fish --location --silent
+#         and source /tmp/installer.fish
+#         and install_pure
+
+#         fish -c 'fish_prompt | grep -c "❯"'
+#     ) = $succeed
+# end
+
+# if test $USER = 'nemo'
+#     @test "installation methods: with fisher" (
+#         fisher install rafaelrinaldi/pure >/dev/null
+
+#         fish -c 'fish_prompt | grep -c "❯"'
+#     ) = $succeed
+# end
+
+# if test $USER = 'nemo'
+#     @test "installation methods: with OMF (Oh-My-Fish!)" (
+#         rm --recursive --force $HOME/.local/share/omf $HOME/.config/omf/
+
+#         curl -L https://get.oh-my.fish > install
+#         and fish install --noninteractive >/dev/null
+
+#         set --global OMF_PURE_PATH $HOME/.local/share/omf/themes/pure
+#         fish -c "omf install pure; \
+#                 ln -sf $OMF_PURE_PATH/functions/*.fish $HOME/.config/fish/functions/; \
+#                 ln -sf $OMF_PURE_PATH/conf.d/* $HOME/.config/fish/conf.d/" > /dev/null
+#         fish -c "fish_prompt" | grep -c '❯'
+#     ) = $succeed
+# end
+
+# if test $USER = 'nemo'
+#     @test "installation methods: with Fundle" (
+#         rm --recursive --force $HOME/.config/fish/fundle/
+#         mkdir -p $HOME/.config/fish/functions
+#         curl https://git.io/fundle --output $HOME/.config/fish/functions/fundle.fish --location --silent >/dev/null
+
+#         fundle plugin rafaelrinaldi/pure >/dev/null
+#         fundle install >/dev/null
+#         cp $HOME/.config/fish/fundle/rafaelrinaldi/pure/{,functions/}fish_prompt.fish
+
+#         fish -c 'fish_prompt | grep -c "❯"'
+#     ) = 1
+# end

--- a/tests/pure_tools_installer.test.fish
+++ b/tests/pure_tools_installer.test.fish
@@ -108,19 +108,6 @@ end
     [ "$_pure_fresh_session" = true ]
 ) $status -eq $SUCCESS
 
-
-
-if test $USER = 'nemo'
-    @test "installer: scaffold fish config directory" (
-        set --global PURE_INSTALL_DIR /tmp/mock/pure
-
-        pure_scaffold_fish_directories >/dev/null
-
-        test    -d $PURE_INSTALL_DIR/functions \
-             -a -d $PURE_INSTALL_DIR/conf.d/
-    ) $status -eq $SUCCESS
-end
-
 if test $USER = 'nemo'
     @test "installer: link configuration and functions to fish config directory" (
         pure_set_pure_install_path "" /tmp/.pure/ >/dev/null
@@ -133,7 +120,6 @@ if test $USER = 'nemo'
             -a -r "$pure_config" -a -L "$pure_config"   # configs and functions are a readable symlink
     ) $status -eq $SUCCESS
 end
-
 
 if test $USER = 'nemo'
     @test "installation methods: manually (with local installer)" (
@@ -162,7 +148,7 @@ end
 set --local fisher_version (fisher --version)
 if is_fisher_4 $fisher_version and test $USER = 'nemo'
     @test "installation methods: with fisher 4.x" (
-        fish -c 'fisher add rafaelrinaldi/pure' >/dev/null 2>&1
+        fish -c 'fisher install rafaelrinaldi/pure' >/dev/null 2>&1
 
         set --global pure_symbol_prompt '>'  # using default ❯ break following tests
         fish -c 'fish_prompt | grep -c ">"'
@@ -202,54 +188,8 @@ if test $USER = 'nemo'
 
         fundle plugin rafaelrinaldi/pure >/dev/null
         fundle install >/dev/null
-        cp $HOME/.config/fish/fundle/rafaelrinaldi/pure/{,functions/}fish_prompt.fish
 
         set --global pure_symbol_prompt '>'  # using default ❯ break following tests
         fish -c "fish_prompt" | grep -c '>'
     ) = $IS_PRESENT
-
-
-if is_fisher_4 and test $USER = 'nemo'
-    @test "installation methods: with fisher 4.x" (
-        fisher install rafaelrinaldi/pure >/dev/null
-
-        fish -c 'fish_prompt | grep -c "❯"'
-    ) = $is_present
-end
-
-if not is_fisher_4 and test $USER = 'nemo'
-    @test "installation methods: with fisher 3.x" (
-        fisher add rafaelrinaldi/pure >/dev/null
-
-        fish -c 'fish_prompt | grep -c "❯"'
-    ) = $is_present
-end
-
-if test $USER = 'nemo'
-    @test "installation methods: with OMF (Oh-My-Fish!)" (
-        rm --recursive --force $HOME/.local/share/omf $HOME/.config/omf/
-
-        curl -L https://get.oh-my.fish > install
-        and fish install --noninteractive >/dev/null
-
-        set --global OMF_PURE_PATH $HOME/.local/share/omf/themes/pure
-        fish -c "omf install pure; \
-                ln -sf $OMF_PURE_PATH/functions/*.fish $HOME/.config/fish/functions/; \
-                ln -sf $OMF_PURE_PATH/conf.d/* $HOME/.config/fish/conf.d/" > /dev/null
-        fish -c "fish_prompt" | grep -c '❯'
-    ) = $is_present
-end
-
-if test $USER = 'nemo'
-    @test "installation methods: with Fundle" (
-        rm --recursive --force $HOME/.config/fish/fundle/
-        mkdir -p $HOME/.config/fish/functions
-        curl https://git.io/fundle --output $HOME/.config/fish/functions/fundle.fish --location --silent >/dev/null
-
-        fundle plugin rafaelrinaldi/pure >/dev/null
-        fundle install >/dev/null
-        cp $HOME/.config/fish/fundle/rafaelrinaldi/pure/{,functions/}fish_prompt.fish
-
-        fish -c 'fish_prompt | grep -c "❯"'
-    ) = $is_present
 end

--- a/tests/pure_tools_installer.test.fish
+++ b/tests/pure_tools_installer.test.fish
@@ -108,8 +108,6 @@ end
     [ "$_pure_fresh_session" = true ]
 ) $status -eq $SUCCESS
 
-
-
 if test $USER = 'nemo'
     @test "installer: link configuration and functions to fish config directory" (
         pure_set_pure_install_path "" /tmp/.pure/ >/dev/null
@@ -120,28 +118,9 @@ if test $USER = 'nemo'
         test \
             -r "$active_prompt" -a -L "$active_prompt" \
             -a -r "$pure_config" -a -L "$pure_config"   # configs and functions are a readable symlink
-    ) $status -eq $succeed
-end
-
-if test $USER = 'nemo'
-    @test "installer: link configuration and functions to fish config directory" (
-        pure_set_pure_install_path "" /tmp/mock/pure >/dev/null
-        mock_install_dir
-        mock_fish_config_dir
-        cp -R ./{fish_*.fish,functions/,conf.d/} $PURE_INSTALL_DIR
-        pure_scaffold_fish_directories >/dev/null
-
-        fish -c 'fish_prompt | grep -c "❯"'
-    ) = $is_present
-end
-
-        set --local active_prompt $FISH_CONFIG_DIR/functions/fish_prompt.fish
-        set --local pure_config $FISH_CONFIG_DIR/conf.d/pure.fish
-        test \
-            -r "$active_prompt" -a -L "$active_prompt" \
-            -a -r "$pure_config" -a -L "$pure_config"   # configs and functions are a readable symlink
     ) $status -eq $SUCCESS
 end
+
 
 if test $USER = 'nemo'
     @test "installation methods: manually (with local installer)" (
@@ -215,7 +194,6 @@ if test $USER = 'nemo'
         set --global pure_symbol_prompt '>'  # using default ❯ break following tests
         fish -c "fish_prompt" | grep -c '>'
     ) = $IS_PRESENT
-end
 
 
 if is_fisher_4 and test $USER = 'nemo'

--- a/tests/pure_tools_installer.test.fish
+++ b/tests/pure_tools_installer.test.fish
@@ -108,6 +108,19 @@ end
     [ "$_pure_fresh_session" = true ]
 ) $status -eq $SUCCESS
 
+
+
+if test $USER = 'nemo'
+    @test "installer: scaffold fish config directory" (
+        set --global PURE_INSTALL_DIR /tmp/mock/pure
+
+        pure_scaffold_fish_directories >/dev/null
+
+        test    -d $PURE_INSTALL_DIR/functions \
+             -a -d $PURE_INSTALL_DIR/conf.d/
+    ) $status -eq $SUCCESS
+end
+
 if test $USER = 'nemo'
     @test "installer: link configuration and functions to fish config directory" (
         pure_set_pure_install_path "" /tmp/.pure/ >/dev/null

--- a/tests/pure_tools_installer.test.fish
+++ b/tests/pure_tools_installer.test.fish
@@ -109,9 +109,24 @@ end
 ) $status -eq $SUCCESS
 
 
+
+function mock_install_dir
+    set --global PURE_INSTALL_DIR /tmp/mock/pure
+    mkdir -p $PURE_INSTALL_DIR
+    cp -R ./{fish_*.fish,functions/,conf.d/} $PURE_INSTALL_DIR
+end
+
+function mock_fish_config_dir
+    set --global FISH_CONFIG_DIR /tmp/mock/config
+    mkdir -p $FISH_CONFIG_DIR/{functions,conf.d}
+end
+
 if test $USER = 'nemo'
     @test "installer: link configuration and functions to fish config directory" (
         pure_set_pure_install_path "" /tmp/.pure/ >/dev/null
+        mock_install_dir
+        mock_fish_config_dir
+
         pure_symlinks_assets >/dev/null
 
         set --local active_prompt $FISH_CONFIG_DIR/functions/fish_prompt.fish

--- a/tests/pure_tools_installer.test.fish
+++ b/tests/pure_tools_installer.test.fish
@@ -110,22 +110,24 @@ end
 
 
 
-function mock_install_dir
-    set --global PURE_INSTALL_DIR /tmp/mock/pure
-    mkdir -p $PURE_INSTALL_DIR
-    cp -R ./{fish_*.fish,functions/,conf.d/} $PURE_INSTALL_DIR
-end
+if test $USER = 'nemo'
+    @test "installer: scaffold fish config directory" (
+        set --global PURE_INSTALL_DIR /tmp/mock/pure
 
-function mock_fish_config_dir
-    set --global FISH_CONFIG_DIR /tmp/mock/config
-    mkdir -p $FISH_CONFIG_DIR/{functions,conf.d}
+        pure_scaffold_fish_directories >/dev/null
+
+        test    -d $PURE_INSTALL_DIR/functions \
+             -a -d $PURE_INSTALL_DIR/conf.d/
+    ) $status -eq 0
 end
 
 if test $USER = 'nemo'
     @test "installer: link configuration and functions to fish config directory" (
-        pure_set_pure_install_path "" /tmp/.pure/ >/dev/null
+        pure_set_pure_install_path "" /tmp/mock/pure >/dev/null
         mock_install_dir
         mock_fish_config_dir
+        cp -R ./{fish_*.fish,functions/,conf.d/} $PURE_INSTALL_DIR
+        pure_scaffold_fish_directories >/dev/null
 
         pure_symlinks_assets >/dev/null
 


### PR DESCRIPTION
~~**:warning: wait for #174 to be merged**~~ content has been merged it this PR
**related:** #170 

---

### Fix

* Ensure `$PURE_INSTALL_DIR/functions` and `$PURE_INSTALL_DIR/conf.d` directory install before installing.
* bump to `2.1.6`

### Test

* [x] update readme section about tests
* [x] revamp makefile to remove duplicate/clumsy code
* [x] add 'how to develop?' section to contributing.md 

`test-pure-on` and `dev-pure-on` now share the same code, only specify the `CMD` to execute in the docker container. Said `CMD` can be overridden by user:

    make dev-pure-on FISH_VERSION=3.0.0 CMD="fishtape tests/fish_greeting.test.fish"