### PR TITLE
Correct iTerm shell integration mark placement

### DIFF
--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -1,4 +1,4 @@
-set --universal pure_version 2.3.0 # used for bug report
+set --universal pure_version 2.3.1 # used for bug report
 
 # Base colors
 _pure_set_default pure_color_primary (set_color blue)

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -3,6 +3,7 @@ function fish_prompt
 
     echo -e -n (_pure_prompt_beginning)  # init prompt context (clear current line, etc.)
     echo -e (_pure_prompt_first_line)  # print current path, git branch/status, command duration
+    _pure_place_iterm2_prompt_mark # place iTerm shell integration mark
     echo -e -n (_pure_prompt $exit_code)  # print prompt
     echo -e (_pure_prompt_ending)  # reset colors and end prompt
 

--- a/functions/_pure_place_iterm2_prompt_mark.fish
+++ b/functions/_pure_place_iterm2_prompt_mark.fish
@@ -1,0 +1,5 @@
+function _pure_place_iterm2_prompt_mark
+    if functions -q iterm2_prompt_mark
+        iterm2_prompt_mark
+    end
+end

--- a/tests/_pure_place_iterm2_prompt_mark.test.fish
+++ b/tests/_pure_place_iterm2_prompt_mark.test.fish
@@ -1,0 +1,13 @@
+source $current_dirname/../functions/_pure_place_iterm2_prompt_mark.fish
+
+set --local empty ''
+
+@test "_pure_place_iterm2_prompt_mark: no iterm2 prompt mark when NOT in iTerm" (
+    echo (_pure_place_iterm2_prompt_mark)
+) = $empty
+
+@test "_pure_place_iterm2_prompt_mark: shows iterm2 prompt mark in iTerm" (
+    function iterm2_prompt_mark; echo 'iterm2-mark'; end
+
+    echo (_pure_place_iterm2_prompt_mark)
+) = 'iterm2-mark'


### PR DESCRIPTION
Related issue already closed: https://github.com/rafaelrinaldi/pure/issues/116. This PR further improves iTerm shell integration with `pure`.