### PR TITLE
Handle virtualenvs that look like flags

### DIFF
--- a/functions/_pure_string_width.fish
+++ b/functions/_pure_string_width.fish
@@ -3,7 +3,7 @@ function _pure_string_width \
     --argument-names prompt
 
     set --local empty ''
-    set --local raw_prompt (string replace --all --regex '\e\[[^m]*m' $empty $prompt)
+    set --local raw_prompt (string replace --all --regex '\e\[[^m]*m' $empty -- $prompt)
 
     string length -- $raw_prompt
 end

--- a/functions/_pure_string_width.fish
+++ b/functions/_pure_string_width.fish
@@ -5,5 +5,5 @@ function _pure_string_width \
     set --local empty ''
     set --local raw_prompt (string replace --all --regex '\e\[[^m]*m' $empty $prompt)
 
-    string length $raw_prompt
+    string length -- $raw_prompt
 end

--- a/tests/_pure_string_width.test.fish
+++ b/tests/_pure_string_width.test.fish
@@ -17,7 +17,7 @@ set --local empty ''
                     (set_color grey)'user@' \
                     (set_color blue)'hostname'
     set prompt (string join "$empty" $prompt)  # do not quote the array
-    
+
     _pure_string_width $prompt
 ) = 13
 
@@ -30,10 +30,13 @@ set --local empty ''
                     (set_color green)'❯⇣' \
                     (set_color yellow)'🦔@' \
                     (set_color grey)'🛡' \
-                    (set_color red)'🚀' 
+                    (set_color red)'🚀'
 
     set prompt (string join "$empty" $prompt)  # do not quote the array
-    
+
     _pure_string_width $prompt
 ) = 6
 
+@test "_pure_string_width: accept double dash in string" (
+    _pure_string_width '--dash'
+) = 6


### PR DESCRIPTION
If you're an idiot like me and end up creating a virtualenv called `--help` (see https://github.com/excitedleigh/virtualfish/issues/146), pure messes up:

```
string length: Unknown option '--help'
~/.config/fish/functions/_pure_string_width.fish (line 9):
    string length $raw_prompt
    ^
```

This PR adds `--` before the `$raw_prompt` argument, which means the `--help` is not treated as a flag.