### PR TITLE
Update workaround for OMF

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 > ##### ✋ Psst! Migrating from v1.x to v2.x? We got you. Check our [**migration guide**](https://github.com/rafaelrinaldi/pure/releases/tag/v2.0.0) and happy upgrading!
 
-# pure [![travis-badge]][travis-link] ![fish-2.5] ![fish-2.6] ![fish-2.7.1] ![fish-3.0.0] 
+# pure [![travis-badge]][travis-link] ![fish-2.5] ![fish-2.6] ![fish-2.7.1] ![fish-3.0.0]
 
 > Pretty, minimal and fast Fish 🐟 prompt, ported from [`zsh`](https://github.com/sindresorhus/pure).
 
@@ -35,6 +35,7 @@ fisher add rafaelrinaldi/pure
 ```fish
 omf install pure
 ln -s $OMF_PATH/themes/pure/conf.d/pure.fish ~/.config/fish/conf.d/pure.fish
+ln -s $OMF_PATH/themes/pure/conf.d/_pure_init.fish ~/.config/fish/conf.d/pure_init.fish
 ```
 
 :information_source: [why the symlink?](https://github.com/rafaelrinaldi/pure/wiki/Oh-My-Fish-not-currently-supporting-conf.d-snippets-in-plugins-and-themes)


### PR DESCRIPTION
The workaround is now incomplete with the private variables extracted to a separate file.

The underscore in the init file name causes it to load before OMF, which causes the new lines to not print. Naming it `pure_init.fish` loads it after `pure.fish`, which mimics the case when the variables weren’t separated.