### PR TITLE
Remove outdated requirements warning from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@
 
 ## Install
 
-**:warning: requirements**: fish `≥2.5`.
-
 ### Manually
 
 Via [cURL](https://curl.haxx.se):


### PR DESCRIPTION
Remove requirements warning from README.md, because pure now supports fish 3. This warning made me very confused...