### PR TITLE
Speed up git dirty

### DIFF
--- a/functions/_pure_prompt_git_dirty.fish
+++ b/functions/_pure_prompt_git_dirty.fish
@@ -3,8 +3,11 @@ function _pure_prompt_git_dirty
     set --local git_dirty_color
 
     set --local is_git_dirty (
+        # The first checks for staged changes, the second for unstaged ones.
+        # We put them in this order because checking staged changes is *fast*.
         not command git diff-index --ignore-submodules --cached --quiet HEAD -- >/dev/null 2>&1
         or not command git diff --ignore-submodules --no-ext-diff --quiet --exit-code >/dev/null 2>&1
+        and echo "true"
     )
     if test -n "$is_git_dirty"  # untracked or un-commited files
         set git_dirty_symbol "$pure_symbol_git_dirty"

--- a/functions/_pure_prompt_git_dirty.fish
+++ b/functions/_pure_prompt_git_dirty.fish
@@ -2,7 +2,10 @@ function _pure_prompt_git_dirty
     set --local git_dirty_symbol
     set --local git_dirty_color
 
-    set --local is_git_dirty (command git status --porcelain --ignore-submodules 2>/dev/null)
+    set --local is_git_dirty (
+        not command git diff-index --ignore-submodules --cached --quiet HEAD -- >/dev/null 2>&1
+        or not command git diff --ignore-submodules --no-ext-diff --quiet --exit-code >/dev/null 2>&1
+    )
     if test -n "$is_git_dirty"  # untracked or un-commited files
         set git_dirty_symbol "$pure_symbol_git_dirty"
         set git_dirty_color "$pure_color_git_dirty"


### PR DESCRIPTION
Idea and implementation is from https://github.com/oh-my-fish/oh-my-fish/pull/706
Modified to ignore submodules

git commands that can exit early.
In large repos, this can be faster by a factor of 15 or so.