### PR TITLE
Allow option to disable git info in prompt

### DIFF
--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -21,6 +21,7 @@ _pure_set_default pure_color_prompt_on_success $pure_color_success
 _pure_set_default pure_color_current_directory $pure_color_primary
 
 # Git
+_pure_set_default pure_enable_git true
 _pure_set_default pure_symbol_git_unpulled_commits "⇣"
 _pure_set_default pure_symbol_git_unpushed_commits "⇡"
 _pure_set_default pure_symbol_git_dirty "*"

--- a/functions/_pure_prompt_first_line.fish
+++ b/functions/_pure_prompt_first_line.fish
@@ -5,10 +5,13 @@ function _pure_prompt_first_line \
         return 1
     end
 
+    set --local prompt_ssh (_pure_prompt_ssh)
+    set --local prompt_git (_pure_prompt_git)
+    set --local prompt_command_duration (_pure_prompt_command_duration)
     set --local prompt (_pure_print_prompt \
-                            (_pure_prompt_ssh) \
-                            (_pure_prompt_git) \
-                            (_pure_prompt_command_duration)
+                            $prompt_ssh \
+                            $prompt_git \
+                            $prompt_command_duration
                         )
     set --local prompt_width (_pure_string_width $prompt)
     set --local current_folder (_pure_prompt_current_folder $prompt_width)
@@ -16,16 +19,16 @@ function _pure_prompt_first_line \
     set --local prompt_components
     if test $pure_begin_prompt_with_current_directory = true
         set prompt_components \
-                (_pure_prompt_current_folder $prompt_width) \
-                (_pure_prompt_git) \
-                (_pure_prompt_ssh) \
-                (_pure_prompt_command_duration)
+                $current_folder \
+                $prompt_git \
+                $prompt_ssh \
+                $prompt_command_duration
     else
         set prompt_components \
-                (_pure_prompt_ssh) \
-                (_pure_prompt_current_folder $prompt_width) \
-                (_pure_prompt_git) \
-                (_pure_prompt_command_duration)
+                $prompt_ssh \
+                $current_folder \
+                $prompt_git \
+                $prompt_command_duration
     end
 
     echo (_pure_print_prompt $prompt_components)

--- a/functions/_pure_prompt_git.fish
+++ b/functions/_pure_prompt_git.fish
@@ -1,6 +1,10 @@
 function _pure_prompt_git \
     --description 'Print git repository informations: branch name, dirty, upstream ahead/behind'
 
+    if test $pure_enable_git != true
+        return
+    end
+
     set --local is_git_repository (command git rev-parse --is-inside-work-tree 2>/dev/null)
 
     if test -n "$is_git_repository"

--- a/tests/_pure_prompt_first_line.test.fish
+++ b/tests/_pure_prompt_first_line.test.fish
@@ -49,6 +49,7 @@ end
 ) = 1
 
 @test "_pure_prompt_first_line: print current directory, git, user@hostname (ssh-only), command duration" (
+    set pure_enable_git true
     set pure_begin_prompt_with_current_directory true
     _pure_prompt_first_line
 
@@ -56,6 +57,7 @@ end
 ) = '/tmp/test master user@hostname 1s'
 
 @test "_pure_prompt_first_line: print user@hostname (ssh-only), current directory, git, command duration" (
+    set pure_enable_git true
     set pure_begin_prompt_with_current_directory false
     _pure_prompt_first_line
 

--- a/tests/_pure_prompt_git.test.fish
+++ b/tests/_pure_prompt_git.test.fish
@@ -27,6 +27,7 @@ end
     function _pure_prompt_git_dirty; echo $empty; end
     function _pure_prompt_git_pending_commits; echo $empty; end
 
+    set pure_enable_git true
     set pure_color_git_branch $empty
     set pure_color_git_dirty $empty
     set pure_color_git_pending_commits $empty
@@ -39,6 +40,7 @@ end
     function _pure_prompt_git_dirty; echo '*'; end
     function _pure_prompt_git_pending_commits; echo $empty; end
 
+    set pure_enable_git true
     set pure_color_git_branch $empty
     set pure_color_git_dirty $empty
     set pure_color_git_pending_commits $empty
@@ -51,9 +53,23 @@ end
     function _pure_prompt_git_dirty; echo $empty; end
     function _pure_prompt_git_pending_commits; echo 'v'; end
 
+    set pure_enable_git true
     set pure_color_git_branch $empty
     set pure_color_git_dirty $empty
     set pure_color_git_pending_commits $empty
 
     _pure_prompt_git
 ) = 'master v'
+
+@test "_pure_prompt_git: returns an empty string when pure_enable_git is false" (
+    git init --quiet
+    function _pure_prompt_git_dirty; echo $empty; end
+    function _pure_prompt_git_pending_commits; echo $empty; end
+
+    set pure_enable_git false
+    set pure_color_git_branch $empty
+    set pure_color_git_dirty $empty
+    set pure_color_git_pending_commits $empty
+
+    _pure_prompt_git
+) $status -eq $succeed


### PR DESCRIPTION
As mentioned in https://github.com/rafaelrinaldi/pure/issues/56#issuecomment-452358451, this provides an option `pure_enable_git` (defaults to `true`) that allows users to disable git integration in the prompt.

Until async is supported, this is useful on slow connections.