### PR TITLE
Add option to show number of jobs in prompt

### DIFF
--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -1,4 +1,4 @@
-set --universal pure_version 2.3.1 # used for bug report
+set --universal pure_version 2.4.0 # used for bug report
 
 # Base colors
 _pure_set_default pure_color_primary (set_color blue)

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -36,7 +36,11 @@ _pure_set_default pure_color_ssh_separator $pure_color_mute
 _pure_set_default pure_color_ssh_user_normal $pure_color_mute
 _pure_set_default pure_color_ssh_user_root $pure_color_light
 
-# Virtualenv for Pyhon
+# Number of running jobs
+_pure_set_default pure_show_jobs false
+_pure_set_default pure_color_jobs $pure_color_normal
+
+# Virtualenv for Python
 _pure_set_default pure_color_virtualenv $pure_color_mute
 
 # Print current working directory at the beginning of prompt

--- a/functions/_pure_prompt.fish
+++ b/functions/_pure_prompt.fish
@@ -2,9 +2,10 @@ function _pure_prompt \
     --description 'Print prompt symbol' \
     --argument-names exit_code
 
+    set --local jobs (_pure_prompt_jobs)
     set --local virtualenv (_pure_prompt_virtualenv) # Python virtualenv name
     set --local vimode_indicator (_pure_prompt_vimode) # vi-mode indicator
     set --local pure_symbol (_pure_prompt_symbol $exit_code)
 
-    echo (_pure_print_prompt $virtualenv $vimode_indicator $pure_symbol)
+    echo (_pure_print_prompt $jobs $virtualenv $vimode_indicator $pure_symbol)
 end

--- a/functions/_pure_prompt_jobs.fish
+++ b/functions/_pure_prompt_jobs.fish
@@ -1,0 +1,8 @@
+function _pure_prompt_jobs --description "Display number of running jobs"
+    if test $pure_show_jobs = true
+        set --local njobs (count (jobs -p))
+        if test $njobs -gt 0
+            echo "$pure_color_jobs"[$njobs]
+        end
+    end
+end

--- a/tests/_pure.test.fish
+++ b/tests/_pure.test.fish
@@ -170,6 +170,12 @@ set --local empty ''
     echo $pure_color_prompt_on_success
 ) = (set_color magenta)
 
+@test "configure: pure_color_jobs"  (
+    set --erase pure_color_jobs
+    source $current_dirname/../conf.d/pure.fish
+    echo $pure_color_jobs
+) = (set_color normal)
+
 @test "configure: pure_color_virtualenv"  (
     set --erase pure_color_virtualenv
     source $current_dirname/../conf.d/pure.fish

--- a/tests/_pure_prompt.test.fish
+++ b/tests/_pure_prompt.test.fish
@@ -1,4 +1,5 @@
 source $current_dirname/../functions/_pure_prompt.fish
+source $current_dirname/../functions/_pure_prompt_jobs.fish
 source $current_dirname/../functions/_pure_prompt_virtualenv.fish
 source $current_dirname/../functions/_pure_prompt_vimode.fish
 source $current_dirname/../functions/_pure_prompt_symbol.fish

--- a/tests/_pure_prompt_jobs.test.fish
+++ b/tests/_pure_prompt_jobs.test.fish
@@ -1,0 +1,15 @@
+source $current_dirname/../functions/_pure_prompt_jobs.fish
+
+set --local success 0
+
+@test "_pure_prompt_jobs: no jobs indicator when there are no jobs" (
+    _pure_prompt_jobs
+) $status -eq $success
+
+@test "_pure_prompt_jobs: displays number of jobs in prompt" (
+    set pure_color_jobs (set_color grey)
+    sleep 5 &
+    _pure_prompt_jobs
+    kill (jobs -p)
+) = (set_color grey)'[1]'
+

--- a/tests/_pure_prompt_jobs.test.fish
+++ b/tests/_pure_prompt_jobs.test.fish
@@ -8,6 +8,7 @@ set --local success 0
 
 @test "_pure_prompt_jobs: displays number of jobs in prompt" (
     set pure_color_jobs (set_color grey)
+    set pure_show_jobs true
     sleep 5 &
     _pure_prompt_jobs
     kill (jobs -p)


### PR DESCRIPTION
Closes #118

By default, the feature is disabled and can be enabled by adding
```fish
set pure_show_jobs true
```
in the user's `config.fish` file.

Additionally, the default color is `normal` to match the [zsh example](https://github.com/sindresorhus/pure/wiki#show-number-of-jobs-in-prompt). This is also configurable.