### PR TITLE
Allow option to disable git info in prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,14 +132,14 @@ MIT © [Rafael Rinaldi](http://rinaldi.io)
 <a href="https://buymeacoff.ee/rinaldi" title="Buy me a coffee">Buy me a ☕</a>
 </p>
 
-[travis-link]: https://travis-ci.org/rafaelrinaldi/pure 'TravisCI'
+[travis-link]: https://travis-ci.org/rafaelrinaldi/pure "TravisCI"
 [travis-badge]: https://travis-ci.org/rafaelrinaldi/pure.svg?branch=master
-[fish-2.5]: https://img.shields.io/badge/fish-v2.5.0-007EC7.svg?style=flat-square 'Support Fish 2.5'
-[fish-2.6]: https://img.shields.io/badge/fish-v2.6.0-007EC7.svg?style=flat-square 'Support Fish 2.6'
-[fish-2.7.1]: https://img.shields.io/badge/fish-v2.7.1-007EC7.svg?style=flat-square 'Support Fish 2.7.1'
-[fish-3.0.0]: https://img.shields.io/badge/fish-v3.0.0-007EC7.svg?style=flat-square 'Support Fish 3.0.0'
-[changelog-2.5]: https://github.com/fish-shell/fish-shell/releases/tag/2.5.0 'Changelog Fish 2.5'
-[changelog-2.6]: https://github.com/fish-shell/fish-shell/releases/tag/2.6.0 'Changelog Fish 2.6'
-[changelog-2.7.1]: https://github.com/fish-shell/fish-shell/releases/tag/2.7.1 'Changelog Fish 2.7.1'
-[changelog-3.0.0]: https://github.com/fish-shell/fish-shell/releases/tag/3.0.0 'Changelog Fish 3.0.0'
-[exit-code]: https://github.com/sindresorhus/pure/wiki#show-exit-code-of-last-command-as-a-separate-prompt-character 'See pure-zsh wiki'
+[fish-2.5]: https://img.shields.io/badge/fish-v2.5.0-007EC7.svg?style=flat-square "Support Fish 2.5"
+[fish-2.6]: https://img.shields.io/badge/fish-v2.6.0-007EC7.svg?style=flat-square "Support Fish 2.6"
+[fish-2.7.1]: https://img.shields.io/badge/fish-v2.7.1-007EC7.svg?style=flat-square "Support Fish 2.7.1"
+[fish-3.0.0]: https://img.shields.io/badge/fish-v3.0.0-007EC7.svg?style=flat-square "Support Fish 3.0.0"
+[changelog-2.5]: https://github.com/fish-shell/fish-shell/releases/tag/2.5.0 "Changelog Fish 2.5"
+[changelog-2.6]: https://github.com/fish-shell/fish-shell/releases/tag/2.6.0 "Changelog Fish 2.6"
+[changelog-2.7.1]: https://github.com/fish-shell/fish-shell/releases/tag/2.7.1 "Changelog Fish 2.7.1"
+[changelog-3.0.0]: https://github.com/fish-shell/fish-shell/releases/tag/3.0.0 "Changelog Fish 3.0.0"
+[exit-code]: https://github.com/sindresorhus/pure/wiki#show-exit-code-of-last-command-as-a-separate-prompt-character "See pure-zsh wiki"

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ You can tweak pretty much everything in `pure` by overriding variables in your `
 
 | Option                                         | Default | Description                                                                                     |
 | :--------------------------------------------- | :------ | :---------------------------------------------------------------------------------------------- |
+| **`pure_enable_git`**                          | `true`  | Show info about Git repository.                                                                 |
 | **`pure_threshold_command_duration`**          | `5`     | Show command duration when above this value (seconds).                                          |
 | **`pure_separate_prompt_on_error`**            | `false` | Show last command [exit code as a separate character][exit-code].                               |
 | **`pure_begin_prompt_with_current_directory`** | `true`  | `true`: _`pwd` `git`, `SSH`, duration_.<br/>`false`: _`SSH` `pwd` `git`, duration_.             |

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -21,6 +21,7 @@ _pure_set_default pure_color_prompt_on_success $pure_color_success
 _pure_set_default pure_color_current_directory $pure_color_primary
 
 # Git
+_pure_set_default pure_enable_git true
 _pure_set_default pure_symbol_git_unpulled_commits "⇣"
 _pure_set_default pure_symbol_git_unpushed_commits "⇡"
 _pure_set_default pure_symbol_git_dirty "*"

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -1,4 +1,4 @@
-set --universal pure_version 2.2.1 # used for bug report
+set --universal pure_version 2.3.0 # used for bug report
 
 # Base colors
 _pure_set_default pure_color_primary (set_color blue)

--- a/functions/_pure_prompt_first_line.fish
+++ b/functions/_pure_prompt_first_line.fish
@@ -5,10 +5,13 @@ function _pure_prompt_first_line \
         return 1
     end
 
+    set --local prompt_ssh (_pure_prompt_ssh)
+    set --local prompt_git (_pure_prompt_git)
+    set --local prompt_command_duration (_pure_prompt_command_duration)
     set --local prompt (_pure_print_prompt \
-                            (_pure_prompt_ssh) \
-                            (_pure_prompt_git) \
-                            (_pure_prompt_command_duration)
+                            $prompt_ssh \
+                            $prompt_git \
+                            $prompt_command_duration
                         )
     set --local prompt_width (_pure_string_width $prompt)
     set --local current_folder (_pure_prompt_current_folder $prompt_width)
@@ -16,16 +19,16 @@ function _pure_prompt_first_line \
     set --local prompt_components
     if test $pure_begin_prompt_with_current_directory = true
         set prompt_components \
-                (_pure_prompt_current_folder $prompt_width) \
-                (_pure_prompt_git) \
-                (_pure_prompt_ssh) \
-                (_pure_prompt_command_duration)
+                $current_folder \
+                $prompt_git \
+                $prompt_ssh \
+                $prompt_command_duration
     else
         set prompt_components \
-                (_pure_prompt_ssh) \
-                (_pure_prompt_current_folder $prompt_width) \
-                (_pure_prompt_git) \
-                (_pure_prompt_command_duration)
+                $prompt_ssh \
+                $current_folder \
+                $prompt_git \
+                $prompt_command_duration
     end
 
     echo (_pure_print_prompt $prompt_components)

--- a/functions/_pure_prompt_git.fish
+++ b/functions/_pure_prompt_git.fish
@@ -1,6 +1,10 @@
 function _pure_prompt_git \
     --description 'Print git repository informations: branch name, dirty, upstream ahead/behind'
 
+    if test $pure_enable_git != true
+        return
+    end
+
     set --local is_git_repository (command git rev-parse --is-inside-work-tree 2>/dev/null)
 
     if test -n "$is_git_repository"

--- a/tests/_pure_prompt_first_line.test.fish
+++ b/tests/_pure_prompt_first_line.test.fish
@@ -49,6 +49,7 @@ end
 ) = 1
 
 @test "_pure_prompt_first_line: print current directory, git, user@hostname (ssh-only), command duration" (
+    set pure_enable_git true
     set pure_begin_prompt_with_current_directory true
     _pure_prompt_first_line
 
@@ -56,6 +57,7 @@ end
 ) = '/tmp/test master user@hostname 1s'
 
 @test "_pure_prompt_first_line: print user@hostname (ssh-only), current directory, git, command duration" (
+    set pure_enable_git true
     set pure_begin_prompt_with_current_directory false
     _pure_prompt_first_line
 

--- a/tests/_pure_prompt_git.test.fish
+++ b/tests/_pure_prompt_git.test.fish
@@ -27,6 +27,7 @@ end
     function _pure_prompt_git_dirty; echo $empty; end
     function _pure_prompt_git_pending_commits; echo $empty; end
 
+    set pure_enable_git true
     set pure_color_git_branch $empty
     set pure_color_git_dirty $empty
     set pure_color_git_pending_commits $empty
@@ -39,6 +40,7 @@ end
     function _pure_prompt_git_dirty; echo '*'; end
     function _pure_prompt_git_pending_commits; echo $empty; end
 
+    set pure_enable_git true
     set pure_color_git_branch $empty
     set pure_color_git_dirty $empty
     set pure_color_git_pending_commits $empty
@@ -51,9 +53,23 @@ end
     function _pure_prompt_git_dirty; echo $empty; end
     function _pure_prompt_git_pending_commits; echo 'v'; end
 
+    set pure_enable_git true
     set pure_color_git_branch $empty
     set pure_color_git_dirty $empty
     set pure_color_git_pending_commits $empty
 
     _pure_prompt_git
 ) = 'master v'
+
+@test "_pure_prompt_git: returns an empty string when pure_enable_git is false" (
+    git init --quiet
+    function _pure_prompt_git_dirty; echo $empty; end
+    function _pure_prompt_git_pending_commits; echo $empty; end
+
+    set pure_enable_git false
+    set pure_color_git_branch $empty
+    set pure_color_git_dirty $empty
+    set pure_color_git_pending_commits $empty
+
+    _pure_prompt_git
+) $status -eq $succeed


### PR DESCRIPTION
As mentioned in https://github.com/rafaelrinaldi/pure/issues/56#issuecomment-452358451, this provides an option `pure_enable_git` (defaults to `true`) that allows users to disable git integration in the prompt.

Until async is supported, this is useful on slow connections.