### PR TITLE
Add test for virtualenvs created through conda

### DIFF
--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -1,4 +1,4 @@
-set --global pure_version 3.1.0 # used for bug report
+set --global pure_version 3.2.0 # used for bug report
 
 # Base colors
 _pure_set_default pure_color_primary blue

--- a/functions/_pure_prompt_virtualenv.fish
+++ b/functions/_pure_prompt_virtualenv.fish
@@ -4,5 +4,10 @@ function _pure_prompt_virtualenv --description "Display virtualenv directory"
         set --local virtualenv_color (_pure_set_color $pure_color_virtualenv)
 
         echo "$virtualenv_color$virtualenv"
+    else if test -n "$CONDA_DEFAULT_ENV"
+        set --local virtualenv (basename "$CONDA_DEFAULT_ENV")
+        set --local virtualenv_color "$pure_color_virtualenv"
+
+        echo "$virtualenv_color$virtualenv"
     end
 end

--- a/functions/_pure_prompt_virtualenv.fish
+++ b/functions/_pure_prompt_virtualenv.fish
@@ -6,7 +6,7 @@ function _pure_prompt_virtualenv --description "Display virtualenv directory"
         echo "$virtualenv_color$virtualenv"
     else if test -n "$CONDA_DEFAULT_ENV"
         set --local virtualenv (basename "$CONDA_DEFAULT_ENV")
-        set --local virtualenv_color "$pure_color_virtualenv"
+        set --local virtualenv_color (_pure_set_color $pure_color_virtualenv)
 
         echo "$virtualenv_color$virtualenv"
     end

--- a/tests/_pure_prompt_virtualenv.test.fish
+++ b/tests/_pure_prompt_virtualenv.test.fish
@@ -2,6 +2,11 @@ source $current_dirname/fixtures/constants.fish
 source $current_dirname/../functions/_pure_prompt_virtualenv.fish
 source $current_dirname/../functions/_pure_set_color.fish
 
+function teardown
+    set --erase --global VIRTUAL_ENV
+    set --erase --global CONDA_DEFAULT_ENV
+end
+
 
 @test "_pure_prompt_virtualenv: hide virtualenv prompt when not activated" (
     set --erase VIRTUAL_ENV
@@ -12,10 +17,9 @@ source $current_dirname/../functions/_pure_set_color.fish
 
 @test "_pure_prompt_virtualenv: displays virtualenv directory prompt" (
     set VIRTUAL_ENV /home/test/fake/project/
-    set pure_color_virtualenv $EMPTY
+    set --global pure_color_virtualenv $EMPTY
 
     _pure_prompt_virtualenv
-    set --erase --global VIRTUAL_ENV
 ) = 'project'
 
 @test "_pure_prompt_virtualenv: hide Conda virtualenv prompt when not activated" (
@@ -27,9 +31,8 @@ source $current_dirname/../functions/_pure_set_color.fish
 
 @test "_pure_prompt_virtualenv: displays Conda virtualenv directory prompt" (
     set CONDA_DEFAULT_ENV /home/test/fake/project/
-    set pure_color_virtualenv $EMPTY
+    set --global pure_color_virtualenv $EMPTY
 
     _pure_prompt_virtualenv
-    set --erase --global CONDA_DEFAULT_ENV
 ) = 'project'
 

--- a/tests/_pure_prompt_virtualenv.test.fish
+++ b/tests/_pure_prompt_virtualenv.test.fish
@@ -12,8 +12,24 @@ source $current_dirname/../functions/_pure_set_color.fish
 
 @test "_pure_prompt_virtualenv: displays virtualenv directory prompt" (
     set VIRTUAL_ENV /home/test/fake/project/
-    set --global pure_color_virtualenv grey
+    set pure_color_virtualenv $EMPTY
 
     _pure_prompt_virtualenv
     set --erase --global VIRTUAL_ENV
-) = (set_color grey)'project'
+) = 'project'
+
+@test "_pure_prompt_virtualenv: hide Conda virtualenv prompt when not activated" (
+    set --erase CONDA_DEFAULT_ENV
+
+    _pure_prompt_virtualenv
+
+) $status -eq $SUCCESS
+
+@test "_pure_prompt_virtualenv: displays Conda virtualenv directory prompt" (
+    set CONDA_DEFAULT_ENV /home/test/fake/project/
+    set pure_color_virtualenv $EMPTY
+
+    _pure_prompt_virtualenv
+    set --erase --global CONDA_DEFAULT_ENV
+) = 'project'
+


### PR DESCRIPTION
Python Virtualenvs created through [Anaconda](https://anaconda.org/) are not currently detected in the pure prompt. 

This simple addition to the virtualenv function fixes that and sets the virtualenv prompt correctly. 