### PR TITLE
Use `git name-rev` as a fallback for branch name

### DIFF
--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -1,4 +1,4 @@
-set --universal pure_version 2.4.0 # used for bug report
+set --universal pure_version 2.4.1 # used for bug report
 
 # Base colors
 _pure_set_default pure_color_primary (set_color blue)

--- a/functions/_pure_parse_git_branch.fish
+++ b/functions/_pure_parse_git_branch.fish
@@ -1,4 +1,4 @@
 function _pure_parse_git_branch --description "Parse current Git branch name"
     command git symbolic-ref --short HEAD 2>/dev/null;
-        or echo (command git show-ref --head -s --abbrev HEAD)[1]
+        or command git name-rev --name-only HEAD 2>/dev/null
 end

--- a/tests/_pure_parse_git_branch.test.fish
+++ b/tests/_pure_parse_git_branch.test.fish
@@ -1,20 +1,35 @@
 source $current_dirname/../functions/_pure_parse_git_branch.fish
 
-set temporary_test_directory /tmp/pure
-
 function setup
-    rm -r -f $temporary_test_directory
-    mkdir -p $temporary_test_directory
-    cd $temporary_test_directory
+    mkdir -p /tmp/test_pure_parse_git_branch # prevent conflict between parallel test files
+    cd /tmp/test_pure_parse_git_branch
+
     git init --quiet
+    git config --global user.email "you@example.com"
+    git config --global user.name "Your Name"
 end
 
 @test "_pure_parse_git_branch: returns current branch" (
-    cd $temporary_test_directory
+    cd /tmp/test_pure_parse_git_branch
 
     _pure_parse_git_branch
 ) = 'master'
 
+
+@test "_pure_parse_git_branch: returns number of commits behind current branch" (
+    touch file.txt
+    git add file.txt
+    git commit --quiet --message="init"
+
+    touch another.txt
+    git add another.txt
+    git commit --quiet --message="another"
+
+    git checkout --quiet "HEAD~1"
+
+    _pure_parse_git_branch
+) = 'master~1'
+
 function teardown
-    rm -r -f $temporary_test_directory
+    rm -r -f /tmp/test_pure_parse_git_branch
 end


### PR DESCRIPTION
This would replace the current usage of `git show-ref`, which displays
commit hash when in detached HEAD, and bring it in line with how the Zsh
version displays branches.

When .git/HEAD is a hash and not a ref (e.g. when you `git checkout
HEAD~#` 
where # is some number of commits behind HEAD), it shows only
the hash.

One oddity to this approach is, if you have many branches or refs
containing common commits, the branch can show as `stash~2`,
`pullreqs/3071~1`, or `fix-colored-yes-perf~1`, for example. Because
this method is more descriptive, I consider this acceptable and better than
the current behavior of only showing the commit hash when in detached
HEAD.