### PR TITLE
Fix empty defaults for base colors

### DIFF
--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -1,4 +1,4 @@
-set --global pure_version 2.5.2 # used for bug report
+set --global pure_version 2.5.3 # used for bug report
 
 # Base colors
 _pure_set_default pure_color_primary blue

--- a/functions/_pure_set_default.fish
+++ b/functions/_pure_set_default.fish
@@ -2,7 +2,7 @@ function _pure_set_default \
     --description 'Set default value for configuration variable' \
     --argument-names var default
 
-    if not set -q --universal $var
+    if not set -q --universal $var; or test -z $$var; and not set -q --global $var
         set --universal $var $default
     end
 end

--- a/functions/_pure_set_default.fish
+++ b/functions/_pure_set_default.fish
@@ -2,7 +2,7 @@ function _pure_set_default \
     --description 'Set default value for configuration variable' \
     --argument-names var default
 
-    if not set -q --universal $var; or test -z $$var; and not set -q --global $var
+    if  not set --query --universal $var; or test -z $$var; and not set --query --global $var
         set --universal $var $default
     end
 end

--- a/tests/_pure_set_default.test.fish
+++ b/tests/_pure_set_default.test.fish
@@ -1,12 +1,32 @@
 source $current_dirname/../functions/_pure_set_default.fish
 
+set --local empty ''
+set --local fail 1
+
+function teardown
+    set --universal --erase my_var
+    set --global --erase my_var
+end
+
 @test "_pure_set_default: set my_var default value" (
     _pure_set_default my_var 'default_value'
     echo $my_var
 ) = 'default_value'
 
-@test "_pure_set_default: skip setting value if default already exists" (
+@test "_pure_set_default: skip setting value if default already exists at universal scope" (
     _pure_set_default my_var 'default_value'
+    _pure_set_default my_var 'another_value'
+    echo $my_var
+) = 'default_value'
+
+@test "_pure_set_default: overwrite UNIVERSAL empty value to make sure the user won't have empty colors." (
+    _pure_set_default my_var $empty
+    _pure_set_default my_var 'default_value'
+    echo $my_var
+) = 'default_value'
+
+@test "_pure_set_default: skip setting value if default already exists at global scope" (
+    set --global my_var 'default_value'
     _pure_set_default my_var 'another_value'
     echo $my_var
 ) = 'default_value'


### PR DESCRIPTION
Sometimes initialization produces empty values when upgrading from the old version. This PR adds an additional check to make sure the user won't have empty colors.