### PR TITLE
Add system time to default prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ set -U pure_symbol_prompt ">"
 | **`pure_begin_prompt_with_current_directory`** | `true`  | `true`: _`pwd` `git`, `SSH`, duration_.<br/>`false`: _`SSH` `pwd` `git`, duration_.             |
 | **`pure_reverse_prompt_symbol_in_vimode`**     | `true`  | `true`: `❮` indicate a non-insert mode.<br/>`false`: indicate vi mode with `[I]`, `[N]`, `[V]`. |
 | **`pure_check_for_new_release false`**         | `false`  | `true`: check repo for new release (on every shell start)
+| **`pure_show_system_time`** | `false` | `true`: shows system time before the prompt symbol (as `%H:%M:%S`).
 
 #### Colors
 

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -40,6 +40,10 @@ _pure_set_default pure_color_ssh_user_root pure_color_light
 _pure_set_default pure_show_jobs false
 _pure_set_default pure_color_jobs pure_color_normal
 
+# Show system time
+_pure_set_default pure_show_system_time false
+_pure_set_default pure_color_system_time pure_color_mute
+
 # Virtualenv for Python
 _pure_set_default pure_color_virtualenv pure_color_mute
 

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -1,4 +1,4 @@
-set --global pure_version 2.6.0 # used for bug report
+set --global pure_version 2.7.0 # used for bug report
 
 # Base colors
 _pure_set_default pure_color_primary blue

--- a/functions/_pure_prompt.fish
+++ b/functions/_pure_prompt.fish
@@ -6,6 +6,7 @@ function _pure_prompt \
     set --local virtualenv (_pure_prompt_virtualenv) # Python virtualenv name
     set --local vimode_indicator (_pure_prompt_vimode) # vi-mode indicator
     set --local pure_symbol (_pure_prompt_symbol $exit_code)
+    set --local system_time (_pure_prompt_system_time)
 
-    echo (_pure_print_prompt $jobs $virtualenv $vimode_indicator $pure_symbol)
+    echo (_pure_print_prompt $system_time $jobs $virtualenv $vimode_indicator $pure_symbol)
 end

--- a/functions/_pure_prompt_system_time.fish
+++ b/functions/_pure_prompt_system_time.fish
@@ -1,0 +1,6 @@
+function _pure_prompt_system_time --description "Display system time"
+    if test $pure_show_system_time = true
+        set --local time_color (_pure_set_color $pure_color_system_time)
+        echo "$time_color"(date +%T)
+    end
+end

--- a/tests/_pure_prompt_system_time.test.fish
+++ b/tests/_pure_prompt_system_time.test.fish
@@ -1,0 +1,17 @@
+source $current_dirname/../functions/_pure_prompt_system_time.fish
+
+set --local success 0
+function _pure_set_color; echo $empty; end # drop coloring during test
+
+@test "_pure_prompt_system_time: no system time when disable" (
+    set --global pure_show_system_time false
+
+    _pure_prompt_system_time
+) $status -eq $success
+
+@test "_pure_prompt_system_time: displays system time when enable" (
+    set --global pure_show_system_time true
+    function date; /bin/date --date='10:01:29' '+%T'; end
+
+    _pure_prompt_system_time
+) = '10:01:29'


### PR DESCRIPTION
I've added support to show a timestamp in the prompt and I thought others might be interested. I made it disabled by default like `pure_show_jobs`. Just to make sure it doesn't interfere with the out-of-the-box clean look.

Not a whole lot else to say about it.

<img width="244" alt="Screen Shot 2020-02-20 at 6 41 10 PM" src="https://user-images.githubusercontent.com/349645/74993469-b91b3780-5410-11ea-916b-4b143501e625.png">
