### PR TITLE
Use default indicator in vi replace mode

### DIFF
--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -1,4 +1,4 @@
-set --global pure_version 3.3.3 # used for bug report
+set --global pure_version 3.3.4 # used for bug report
 
 # Base colors
 _pure_set_default pure_color_primary blue

--- a/functions/_pure_get_prompt_symbol.fish
+++ b/functions/_pure_get_prompt_symbol.fish
@@ -3,12 +3,10 @@ function _pure_get_prompt_symbol \
     --argument-names exit_code
 
     set --local prompt_symbol $pure_symbol_prompt
-    set --local is_vi_mode (string match -r "fish_(vi|hybrid)_key_bindings" $fish_key_bindings)
-    if test -n "$is_vi_mode" \
-            -a "$pure_reverse_prompt_symbol_in_vimode" = true \
-            -a "$fish_bind_mode" != "insert"
-        set prompt_symbol $pure_symbol_reverse_prompt
-    end
+    test "$pure_reverse_prompt_symbol_in_vimode" = true
+    and string match -rq "fish_(vi|hybrid)_key_bindings" $fish_key_bindings
+    and not contains "$fish_bind_mode" insert replace
+    and set prompt_symbol $pure_symbol_reverse_prompt
 
     echo "$prompt_symbol"
 end

--- a/tests/_pure_get_prompt_symbol.test.fish
+++ b/tests/_pure_get_prompt_symbol.test.fish
@@ -33,7 +33,23 @@ end
     _pure_get_prompt_symbol
 ) = '❯'
 
-@test "_pure_get_prompt_symbol: get reverse symbol ❮ when VI key binding and not in insert mode" (
+@test "_pure_get_prompt_symbol: get default symbol ❯ when VI key binding and in insert mode" (
+    set pure_reverse_prompt_symbol_in_vimode true
+    set fish_bind_mode 'insert'
+    set fish_key_bindings 'fish_vi_key_bindings'
+
+    _pure_get_prompt_symbol
+) = '❯'
+
+@test "_pure_get_prompt_symbol: get default symbol ❯ when VI key binding and in replace mode" (
+    set pure_reverse_prompt_symbol_in_vimode true
+    set fish_bind_mode 'replace'
+    set fish_key_bindings 'fish_vi_key_bindings'
+
+    _pure_get_prompt_symbol
+) = '❯'
+
+@test "_pure_get_prompt_symbol: get reverse symbol ❮ when VI key binding and not in insert mode or replace mode" (
     set pure_reverse_prompt_symbol_in_vimode true
     set fish_bind_mode 'default'
     set fish_key_bindings 'fish_vi_key_bindings'
@@ -41,7 +57,7 @@ end
     _pure_get_prompt_symbol
 ) = '❮'
 
-@test "_pure_get_prompt_symbol: get reverse symbol ❮ when hybrid key binding and not in insert mode" (
+@test "_pure_get_prompt_symbol: get reverse symbol ❮ when hybrid key binding and not in insert mode or replace mode" (
     set pure_reverse_prompt_symbol_in_vimode true
     set fish_bind_mode 'default'
     set fish_key_bindings 'fish_hybrid_key_bindings'


### PR DESCRIPTION
It is consistent with the ZSH version of `pure`. `R` goes into `replace` mode in Fish, but `viins` mode in ZSH, so it makes sense to use the default indicator instead of the reverse one.