### PR TITLE
Fix command duration issues, also add show subsecond support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ or changing the defaults in your `config.fish`:
 
 | Option                                 | Default | Description                                          |
 | :------------------------------------- | :------ | :--------------------------------------------------- |
-| **`pure_symbol_prompt`**               | `❯`     | Prompt symbol.                                       |
-| **`pure_symbol_reverse_prompt`**       | `❮`     | VI non-insert mode symbol.                           |
+| **`pure_symbol_git_dirty`**            | `*`     | Repository is Dirty (uncommitted/untracked changes). |
 | **`pure_symbol_git_unpulled_commits`** | `⇣`     | Branch is behind upstream (commits to pull).         |
 | **`pure_symbol_git_unpushed_commits`** | `⇡`     | Branch is ahead upstream (commits to push).          |
-| **`pure_symbol_git_dirty`**            | `*`     | Repository is Dirty (uncommitted/untracked changes). |
+| **`pure_symbol_prompt`**               | `❯`     | Prompt symbol.                                       |
+| **`pure_symbol_reverse_prompt`**       | `❮`     | VI non-insert mode symbol.                           |
 | **`pure_symbol_title_bar_separator`**  | `—`     |
 :information_source:: Need [safer `git` symbols](https://github.com/sindresorhus/pure/wiki#safer-symbols)?
 
@@ -95,17 +95,15 @@ or changing the defaults in your `config.fish`:
 
 | Option                                         | Default | Description                                                                                     |
 | :--------------------------------------------- | :------ | :---------------------------------------------------------------------------------------------- |
+| **`pure_begin_prompt_with_current_directory`** | `true`  | `true`: _`pwd` `git`, `SSH`, duration_.<br/>`false`: _`SSH` `pwd` `git`, duration_.             |
+| **`pure_check_for_new_release`**               | `false` | `true`: check repo for new release (on every shell start)                                       |
 | **`pure_enable_git`**                          | `true`  | Show info about Git repository.                                                                 |
+| **`pure_reverse_prompt_symbol_in_vimode`**     | `true`  | `true`: `❮` indicate a non-insert mode.<br/>`false`: indicate vi mode with `[I]`, `[N]`, `[V]`. |
+| **`pure_separate_prompt_on_error`**            | `false` | Show last command [exit code as a separate character][exit-code].                               |
 | **`pure_show_jobs`**                           | `false` | Show Number of running jobs                                                                     |
+| **`pure_show_subsecond_command_duration`**     | `false` | Show subsecond (ex. 1.5s) in command duration.                                                  |
 | **`pure_show_system_time`**                    | `false` | `true`: shows system time before the prompt symbol (as `%H:%M:%S`).                             |
 | **`pure_threshold_command_duration`**          | `5`     | Show command duration when above this value (seconds).                                          |
-| **`pure_show_subsecond_command_duration`**     | `false` | Show subsecond (ex. 1.5s) in command duration.                                                  |
-| **`pure_separate_prompt_on_error`**            | `false` | Show last command [exit code as a separate character][exit-code].                               |
-| **`pure_begin_prompt_with_current_directory`** | `true`  | `true`: _`pwd` `git`, `SSH`, duration_.<br/>`false`: _`SSH` `pwd` `git`, duration_.             |
-| **`pure_separate_prompt_on_error`**            | `false` | Show last command [exit code as a separate character][exit-code].                               |
-| **`pure_threshold_command_duration`**          | `5`     | Show command duration when above this value (seconds).                                          |
-| **`pure_reverse_prompt_symbol_in_vimode`**     | `true`  | `true`: `❮` indicate a non-insert mode.<br/>`false`: indicate vi mode with `[I]`, `[N]`, `[V]`. |
-| **`pure_check_for_new_release`**               | `false` | `true`: check repo for new release (on every shell start)                                       |
 
 ### Colors
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ or changing the defaults in your `config.fish`:
 | **`pure_enable_git`**                          | `true`  | Show info about Git repository.                                                                 |
 | **`pure_show_jobs`**                           | `false` | Show Number of running jobs                                                                     |
 | **`pure_show_system_time`**                    | `false` | `true`: shows system time before the prompt symbol (as `%H:%M:%S`).                             |
+| **`pure_threshold_command_duration`**          | `5`     | Show command duration when above this value (seconds).                                          |
+| **`pure_show_subsecond_command_duration`**     | `false` | Show subsecond (ex. 1.5s) in command duration.                                                  |
+| **`pure_separate_prompt_on_error`**            | `false` | Show last command [exit code as a separate character][exit-code].                               |
 | **`pure_begin_prompt_with_current_directory`** | `true`  | `true`: _`pwd` `git`, `SSH`, duration_.<br/>`false`: _`SSH` `pwd` `git`, duration_.             |
 | **`pure_separate_prompt_on_error`**            | `false` | Show last command [exit code as a separate character][exit-code].                               |
 | **`pure_threshold_command_duration`**          | `5`     | Show command duration when above this value (seconds).                                          |

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -60,6 +60,7 @@ _pure_set_default pure_separate_prompt_on_error false
 
 # Max execution time of a process before its run time is shown when it exits
 _pure_set_default pure_threshold_command_duration 5
+_pure_set_default pure_show_subsecond_command_duration false
 _pure_set_default pure_color_command_duration pure_color_warning
 
 # VI mode indicator

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -1,4 +1,4 @@
-set --global pure_version 3.2.0 # used for bug report
+set --global pure_version 3.3.0 # used for bug report
 
 # Base colors
 _pure_set_default pure_color_primary blue

--- a/functions/_pure_format_time.fish
+++ b/functions/_pure_format_time.fish
@@ -2,30 +2,30 @@ set FAILURE 1
 
 function _pure_format_time \
     --description="Format milliseconds to a human readable format" \
-    --argument-names milliseconds threshold
+    --argument-names milliseconds threshold show_subsecond
 
-    if test $milliseconds -lt 0; return $FAILURE; end
+    test $milliseconds -lt 0; and return $fail
+    test $milliseconds -lt (math -s0 "$threshold * 1000"); and echo; and return 0
 
-    set --local seconds (math -s0 "$milliseconds / 1000 % 60")
-    set --local minutes (math -s0 "$milliseconds / 60000 % 60")
-    set --local hours (math -s0 "$milliseconds / 3600000 % 24")
-    set --local days (math -s0 "$milliseconds / 86400000")
     set --local time
 
-    if test $days -gt 0
-        set time $time (printf "%sd" $days)
-    end
+    set --local days (math -s0 "$milliseconds / 86400000")
+    test $days -gt 0; and set time $time (printf "%sd" $days)
 
-    if test $hours -gt 0
-        set time $time (printf "%sh" $hours)
-    end
+    set --local hours (math -s0 "$milliseconds / 3600000 % 24")
+    test $hours -gt 0; and set time $time (printf "%sh" $hours)
 
-    if test $minutes -gt 0
-        set time $time (printf "%sm" $minutes)
-    end
+    set --local minutes (math -s0 "$milliseconds / 60000 % 60")
+    test $minutes -gt 0; and set time $time (printf "%sm" $minutes)
 
-    if test $seconds -gt $threshold
-        set time $time (printf "%ss" $seconds)
+    set --local seconds (math -s0 "$milliseconds / 1000 % 60")
+    if test $show_subsecond = true
+        if test $milliseconds -gt 0
+            set --local subsec (string sub -s -3 -l 2 00$milliseconds | string trim -r -c 0)
+            set time $time $seconds(test -n "$subsec"; and echo '.'$subsec; or echo)'s'
+        end
+    else
+        test $seconds -gt 0; and set time $time (printf "%ss" $seconds)
     end
 
     echo -e (string join ' ' $time)

--- a/functions/_pure_format_time.fish
+++ b/functions/_pure_format_time.fish
@@ -5,23 +5,23 @@ function _pure_format_time \
     --argument-names milliseconds threshold show_subsecond
 
     test $milliseconds -lt 0; and return $fail
-    test $milliseconds -lt (math -s0 "$threshold * 1000"); and echo; and return 0
+    test $milliseconds -lt (math --scale=0 "$threshold * 1000"); and echo; and return $SUCCESS
 
     set --local time
 
-    set --local days (math -s0 "$milliseconds / 86400000")
-    test $days -gt 0; and set time $time (printf "%sd" $days)
+    set --local days (math --scale=0 "$milliseconds / 86400000")
+    test $days -gt 0; and set --append time (printf "%sd" $days)
 
-    set --local hours (math -s0 "$milliseconds / 3600000 % 24")
-    test $hours -gt 0; and set time $time (printf "%sh" $hours)
+    set --local hours (math --scale=0 "$milliseconds / 3600000 % 24")
+    test $hours -gt 0; and set --append time (printf "%sh" $hours)
 
-    set --local minutes (math -s0 "$milliseconds / 60000 % 60")
-    test $minutes -gt 0; and set time $time (printf "%sm" $minutes)
+    set --local minutes (math --scale=0 "$milliseconds / 60000 % 60")
+    test $minutes -gt 0; and set --append time (printf "%sm" $minutes)
 
-    set --local seconds (math -s0 "$milliseconds / 1000 % 60")
+    set --local seconds (math --scale=0 "$milliseconds / 1000 % 60")
     if test $show_subsecond = true
         if test $milliseconds -gt 0
-            set --local subsec (string sub -s -3 -l 2 00$milliseconds | string trim -r -c 0)
+            set --local subsec (string sub --start -3 --length 2 00$milliseconds | string trim --right --chars 0)
             set time $time $seconds(test -n "$subsec"; and echo '.'$subsec; or echo)'s'
         end
     else

--- a/functions/_pure_format_time.fish
+++ b/functions/_pure_format_time.fish
@@ -22,10 +22,10 @@ function _pure_format_time \
     if test $show_subsecond = true
         if test $milliseconds -gt 0
             set --local subsec (string sub --start -3 --length 2 00$milliseconds | string trim --right --chars 0)
-            set time $time $seconds(test -n "$subsec"; and echo '.'$subsec; or echo)'s'
+            set --append time $seconds(test -n "$subsec"; and echo '.'$subsec; or echo)'s'
         end
     else
-        test $seconds -gt 0; and set time $time (printf "%ss" $seconds)
+        test $seconds -gt 0; and set --append time (printf "%ss" $seconds)
     end
 
     echo -e (string join ' ' $time)

--- a/functions/_pure_format_time.fish
+++ b/functions/_pure_format_time.fish
@@ -3,8 +3,12 @@ set FAILURE 1
 
 function _pure_format_time \
     --description="Format milliseconds to a human readable format" \
-    --argument-names milliseconds threshold show_subsecond
+    --argument-names \
+        milliseconds \
+        threshold \
+        show_subsecond
 
+    set --query show_subsecond[1]; or set show_subsecond false
     test $milliseconds -lt 0; and return $FAILURE
     test $milliseconds -lt (math --scale=0 "$threshold * 1000"); and echo; and return $SUCCESS
 

--- a/functions/_pure_format_time.fish
+++ b/functions/_pure_format_time.fish
@@ -13,25 +13,37 @@ function _pure_format_time \
     test $milliseconds -lt (math --scale=0 "$threshold * 1000"); and echo; and return $SUCCESS
 
     set --local time
-
     set --local days (math --scale=0 "$milliseconds / 86400000")
     test $days -gt 0; and set --append time (printf "%sd" $days)
-
     set --local hours (math --scale=0 "$milliseconds / 3600000 % 24")
     test $hours -gt 0; and set --append time (printf "%sh" $hours)
-
     set --local minutes (math --scale=0 "$milliseconds / 60000 % 60")
     test $minutes -gt 0; and set --append time (printf "%sm" $minutes)
-
     set --local seconds (math --scale=0 "$milliseconds / 1000 % 60")
+
     if test $show_subsecond = true
-        if test $milliseconds -gt 0
-            set --local subsec (string sub --start -3 --length 2 00$milliseconds | string trim --right --chars 0)
-            set --append time $seconds(test -n "$subsec"; and echo '.'$subsec; or echo)'s'
-        end
+        set --local threshold_as_ms (math --scale=0 "$threshold*1000")
+        set --local subseconds (_pure_format_time_subseconds $milliseconds $threshold_as_ms)
+        set --append time $seconds$subseconds's'
     else
-        test $seconds -gt 0; and set --append time (printf "%ss" $seconds)
+        test $seconds -gt $threshold; and set --append time (printf "%ss" $seconds)
     end
 
     echo -e (string join ' ' $time)
+end
+
+
+function _pure_format_time_subseconds \
+    --description="Format duration milliseconds to a human readable format" \
+    --argument-names \
+        duration \
+        threshold
+
+    set --local subseconds
+    if test $duration -gt $threshold
+        set --local precision 2
+        set --local milliseconds (string sub --start -3 --length $precision $duration)
+        set --append subseconds '.'$milliseconds
+    end
+    echo $subseconds
 end

--- a/functions/_pure_format_time.fish
+++ b/functions/_pure_format_time.fish
@@ -1,10 +1,11 @@
+set SUCCESS 0
 set FAILURE 1
 
 function _pure_format_time \
     --description="Format milliseconds to a human readable format" \
     --argument-names milliseconds threshold show_subsecond
 
-    test $milliseconds -lt 0; and return $fail
+    test $milliseconds -lt 0; and return $FAILURE
     test $milliseconds -lt (math --scale=0 "$threshold * 1000"); and echo; and return $SUCCESS
 
     set --local time

--- a/functions/_pure_prompt_command_duration.fish
+++ b/functions/_pure_prompt_command_duration.fish
@@ -3,7 +3,7 @@ function _pure_prompt_command_duration
 
     # Get command execution duration
     if test -n "$CMD_DURATION"
-        set command_duration (_pure_format_time $CMD_DURATION $pure_threshold_command_duration)
+        set command_duration (_pure_format_time $CMD_DURATION $pure_threshold_command_duration $pure_show_subsecond_command_duration)
     end
     set --local command_duration_color (_pure_set_color $pure_color_command_duration)
 

--- a/tests/_pure_format_time.test.fish
+++ b/tests/_pure_format_time.test.fish
@@ -16,8 +16,8 @@ set --local threshold 0 # in seconds
 ) = $EMPTY
 
 @test "_pure_format_time: format 1s to human" (
-    set --local milliseconds 1000 # express as milliseconds
-    _pure_format_time (math "1*$milliseconds") $threshold
+    set --local millisecond 1000 # express as milliseconds
+    _pure_format_time (math "1*$millisecond") $threshold
 ) = '1s'
 
 @test "_pure_format_time: format 1050ms to human (show milliseconds)" (
@@ -26,33 +26,33 @@ set --local threshold 0 # in seconds
 ) = '1.05s'
 
 @test "_pure_format_time: format 60s as a minutes to human" (
-    set --local milliseconds 1000 # express as milliseconds
-    _pure_format_time (math "60*$milliseconds") $threshold
+    set --local millisecond 1000 # express as milliseconds
+    _pure_format_time (math "60*$millisecond") $threshold
 ) = '1m'
 
 @test "_pure_format_time: format 59 minutes to human" (
-    set --local minutes 60000 # express as milliseconds
-    _pure_format_time (math "59*$minutes") $threshold
+    set --local minute 60000 # express as milliseconds
+    _pure_format_time (math "59*$minute") $threshold
 ) = '59m'
 
 @test "_pure_format_time: format 60min as an hour to human" (
-    set --local minutes 60000 # express as milliseconds
-    _pure_format_time (math "60*$minutes") $threshold
+    set --local minute 60000 # express as milliseconds
+    _pure_format_time (math "60*$minute") $threshold
 ) = '1h'
 
 @test "_pure_format_time: format 23 hours to human" (
-    set --local hours 3600000 # express as milliseconds
-    _pure_format_time (math "23*$hours") $threshold
+    set --local hour 3600000 # express as milliseconds
+    _pure_format_time (math "23*$hour") $threshold
 ) = '23h'
 
 @test "_pure_format_time: format 24 hours as a day to human" (
-    set --local hours 3600000 # express as milliseconds
-    _pure_format_time (math "24*$hours") $threshold
+    set --local hour 3600000 # express as milliseconds
+    _pure_format_time (math "24*$hour") $threshold
 ) = '1d'
 
 @test "_pure_format_time: format days to human" (
-    set --local days 86400000 # express as milliseconds
-    _pure_format_time (math "100*$days") $threshold
+    set --local day 86400000 # express as milliseconds
+    _pure_format_time (math "100*$day") $threshold
 ) = '100d'
 
 @test "_pure_format_time: format complex duration to human" (

--- a/tests/_pure_format_time.test.fish
+++ b/tests/_pure_format_time.test.fish
@@ -11,18 +11,23 @@ set --local threshold 0 # in seconds
 
 @test "_pure_format_time: returns nothing if duration is below thresold time" (
     set --local duration 0 # ms
-    set --local threshold 1 # ms
+    set --local threshold 1 # s
     _pure_format_time $duration $threshold
 ) = $EMPTY
 
 @test "_pure_format_time: format 1s to human" (
-    set --local seconds 1000 # express as milliseconds
-    _pure_format_time (math "1*$seconds") $threshold
+    set --local milliseconds 1000 # express as milliseconds
+    _pure_format_time (math "1*$milliseconds") $threshold
 ) = '1s'
 
+@test "_pure_format_time: format 1050ms to human (show milliseconds)" (
+    set --local milliseconds 1053 # express as milliseconds
+    _pure_format_time (math "1*$milliseconds") $threshold true
+) = '1.05s'
+
 @test "_pure_format_time: format 60s as a minutes to human" (
-    set --local seconds 1000 # express as milliseconds
-    _pure_format_time (math "60*$seconds") $threshold
+    set --local milliseconds 1000 # express as milliseconds
+    _pure_format_time (math "60*$milliseconds") $threshold
 ) = '1m'
 
 @test "_pure_format_time: format 59 minutes to human" (

--- a/tests/_pure_format_time.test.fish
+++ b/tests/_pure_format_time.test.fish
@@ -58,3 +58,21 @@ set --local threshold 0 # in seconds
 @test "_pure_format_time: format complex duration to human" (
     _pure_format_time 123456789 $threshold
 ) = '1d 10h 17m 36s'
+
+@test "_pure_format_time_subseconds: empty when below threshold" (
+    set --local milliseconds 953 # express as milliseconds
+    set --local threshold 1000 # express as milliseconds
+    _pure_format_time_subseconds $milliseconds $threshold
+) = $EMPTY
+
+@test "_pure_format_time_subseconds: show subsecond when above threshold" (
+    set --local milliseconds 1053 # express as milliseconds
+    set --local threshold 1000 # express as milliseconds
+    _pure_format_time_subseconds $milliseconds $threshold
+) = '.05'
+
+@test "_pure_format_time_subseconds: keep precision with zero-ending" (
+    set --local milliseconds 1200 # express as milliseconds
+    set --local threshold 1000 # express as milliseconds
+    _pure_format_time_subseconds $milliseconds $threshold
+) = '.20'

--- a/tests/_pure_prompt_command_duration.test.fish
+++ b/tests/_pure_prompt_command_duration.test.fish
@@ -12,9 +12,18 @@ source $current_dirname/../functions/_pure_set_color.fish
 ) = $EMPTY
 
 @test "_pure_prompt_command_duration: displays command duration when non-zero" (
-    set CMD_DURATION 6000 # in milliseconds
+    set CMD_DURATION 6053 # in milliseconds
     set --global pure_threshold_command_duration 5 # in seconds
     set --global pure_color_command_duration $EMPTY
 
     _pure_prompt_command_duration
 ) = '6s'
+
+@test "_pure_prompt_command_duration: displays command duration with ms when non-zero" (
+    set CMD_DURATION 6053 # in milliseconds
+    set --global pure_threshold_command_duration 5 # in seconds
+    set --global pure_show_subsecond_command_duration true
+    set --global pure_color_command_duration $empty
+
+    _pure_prompt_command_duration
+) = '6.05s'


### PR DESCRIPTION
- Fix command duration rounding: Duration wasn't shown when:
    + When threshold = 5 (5000ms)
    + When process finished in [5000, 6000) miliseconds
- Fix command duration threshold: Duration wasn't shown when:
    + When threshold = 5 (5000ms)
    + When process finished in 1m4s (64 seconds)
- Add support for showing subsecond in command duration
  via `pure_show_subsecond_command_duration`