### PR TITLE
WIP: Add fishfile to manage dependencies

### DIFF
--- a/fishfile
+++ b/fishfile
@@ -1,0 +1,1 @@
+acomagu/fish-async-prompt


### PR DESCRIPTION
Add `fish-async-prompt` as a package dependency to allow prompt
functions to be executed asynchronously.

Closes #56.