### PR TITLE
Remove virtualenv from prompt for now.

### DIFF
--- a/functions/_pure_prompt.fish
+++ b/functions/_pure_prompt.fish
@@ -3,7 +3,7 @@ function _pure_prompt \
     --argument-names exit_code
 
     set --local jobs (_pure_prompt_jobs)
-    set --local virtualenv (_pure_prompt_virtualenv) # Python virtualenv name
+    set --local virtualenv ""
     set --local vimode_indicator (_pure_prompt_vimode) # vi-mode indicator
     set --local pure_symbol (_pure_prompt_symbol $exit_code)
 


### PR DESCRIPTION
Why: pure doesn't currently respect the VIRTURAL_ENV_DISABLE_PROMPT
environment variable. This makes my prompt super messy when working in
a virtual env. Plus, I have logic setup to have the venv on the right
prompt.

How: For now, just return an empty string.

Tags: fish, prompt, virtualenv, python