### PR TITLE
Flag to Check for new release on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ set -U pure_symbol_prompt ">"
 | **`pure_symbol_git_unpushed_commits`** | `⇡`     | Branch is ahead upstream (commits to push).          |
 | **`pure_symbol_git_dirty`**            | `*`     | Repository is Dirty (uncommitted/untracked changes). |
 | **`pure_symbol_title_bar_separator`**  | `—`     |
-
 :information_source:: Need [safer `git` symbols](https://github.com/sindresorhus/pure/wiki#safer-symbols)?
 
 #### Features
@@ -100,6 +99,7 @@ set -U pure_symbol_prompt ">"
 | **`pure_separate_prompt_on_error`**            | `false` | Show last command [exit code as a separate character][exit-code].                               |
 | **`pure_begin_prompt_with_current_directory`** | `true`  | `true`: _`pwd` `git`, `SSH`, duration_.<br/>`false`: _`SSH` `pwd` `git`, duration_.             |
 | **`pure_reverse_prompt_symbol_in_vimode`**     | `true`  | `true`: `❮` indicate a non-insert mode.<br/>`false`: indicate vi mode with `[I]`, `[N]`, `[V]`. |
+| **`pure_check_for_new_release false`**         | `false`  | `true`: check repo for new release (on every shell start)
 
 #### Colors
 

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -64,3 +64,6 @@ _pure_set_default pure_reverse_prompt_symbol_in_vimode true
 
 # Title
 _pure_set_default pure_symbol_title_bar_separator "—"
+
+# Check for new release on startup
+_pure_set_default pure_check_for_new_release false

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -1,4 +1,4 @@
-set --global pure_version 2.5.3 # used for bug report
+set --global pure_version 2.6.0 # used for bug report
 
 # Base colors
 _pure_set_default pure_color_primary blue

--- a/functions/_pure_check_for_new_release.fish
+++ b/functions/_pure_check_for_new_release.fish
@@ -1,0 +1,14 @@
+function _pure_check_for_new_release \
+    --description "Check for new release and show command to install"
+
+    if test $pure_check_for_new_release = true
+        echo "🛈 Checking for new release…"
+        set latest (curl --silent "https://api.github.com/repos/rafaelrinaldi/pure/releases/latest" | sed -n 's/.*tag_name":\s"v\(.*\)".*/\1/p')
+
+        if test $pure_version != $latest
+            set --local latest_version (_pure_set_color $pure_color_info)$latest(_pure_set_color pure_color_normal)
+            echo -e "🔔 New version available!\n"
+            echo -e (_pure_set_color $pure_color_success)"fisher install rafaelrinaldi/pure@$latest_version\n"
+        end
+    end
+end

--- a/functions/fish_greeting.fish
+++ b/functions/fish_greeting.fish
@@ -1,2 +1,3 @@
 function fish_greeting
+    _pure_check_for_new_release
 end

--- a/tests/_pure_check_for_new_release.test.fish
+++ b/tests/_pure_check_for_new_release.test.fish
@@ -1,5 +1,4 @@
 source $current_dirname/../functions/_pure_check_for_new_release.fish
-source $current_dirname/../functions/_pure_prompt_ending.fish
 
 set --local succeed 0
 set --local empty ''

--- a/tests/_pure_check_for_new_release.test.fish
+++ b/tests/_pure_check_for_new_release.test.fish
@@ -1,0 +1,31 @@
+source $current_dirname/../functions/_pure_check_for_new_release.fish
+source $current_dirname/../functions/_pure_prompt_ending.fish
+
+set --local succeed 0
+set --local empty ''
+function _pure_set_color; echo $empty; end # drop coloring during test
+
+@test "_pure_check_for_new_release: is disabled" (
+    set --global pure_check_for_new_release false
+
+    _pure_check_for_new_release
+) $status -eq $succeed
+
+
+@test "_pure_check_for_new_release: nothing when same as latest" (
+    set --global pure_check_for_new_release true
+    set --global pure_version 0.0.1
+    function curl; echo '"tag_name": "v0.0.1",'; end # mock
+
+    _pure_check_for_new_release
+) = '🛈 Checking for new release…'
+
+@test "_pure_check_for_new_release: show fisher command to install when enable" (
+    set --global pure_check_for_new_release true
+    set --global pure_version 0.0.1
+    function curl; echo '"tag_name": "v9.9.9",'; end # mock
+
+    set output (_pure_check_for_new_release 2>&1)
+    echo $output[2] $output[4]
+) = '🔔 New version available! fisher install rafaelrinaldi/pure@9.9.9'
+

--- a/tests/fish_greeting.test.fish
+++ b/tests/fish_greeting.test.fish
@@ -1,6 +1,7 @@
 source $current_dirname/../functions/fish_greeting.fish
 
 set --local succeed 0
+function _pure_check_for_new_release; echo ''; end
 
 @test "fish_greeting: succeed" (
     fish_greeting


### PR DESCRIPTION
**related:** closes #131

---

| Option                                         | Default | Description                                                                                     |
| :--------------------------------------------- | :------ | :---------------------------------------------------------------------------------------------- |
| **`pure_check_for_new_release false`**         | `false`  | `true`: check repo for new release (on every shell start)

As this request can disrupt user workflow due to the HTTP request done to fetch information, this feature is disable by default. It's up to the user to decide if he want to enable it.

### Preview

![pure_check_for_new_release](https://user-images.githubusercontent.com/1212392/99608817-f39d1980-2a0e-11eb-8fd1-65cad4bd7342.gif)
