### PR TITLE
run CI on latest Ubuntu and MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest]
         fish_version: [
           "3.1.2",
           "3.1.0",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,48 +2,48 @@ name: Run tests on CI
 on: [push, pull_request]
 
 jobs:
-  test-ubuntu:
-    name: Test on fish on Ubuntu
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install Fish
-        run: |
-          sudo apt-add-repository -yn ppa:fish-shell/release-3
-          sudo apt-get update
-          sudo apt-get install -y fish
-      - name: Install Fisher > Fishtape > Pure
-        run: |
-          curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher jorgebucaran/fishtape ./
-        shell: fish {0}
-      - name: Test Pure
-        run: fishtape tests/*.test.fish
-        shell: fish {0}
+  # test-ubuntu:
+  #   name: Test on fish on Ubuntu
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install Fish
+  #       run: |
+  #         sudo apt-add-repository -yn ppa:fish-shell/release-3
+  #         sudo apt-get update
+  #         sudo apt-get install -y fish
+  #     - name: Install Fisher > Fishtape > Pure
+  #       run: |
+  #         curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher jorgebucaran/fishtape ./
+  #       shell: fish {0}
+  #     - name: Test Pure
+  #       run: fishtape tests/*.test.fish
+  #       shell: fish {0}
 
 
-  test-container:
-    name: Test on fish ${{ matrix.fish_version }} on Docker
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        fish_version:
-          - "3.1.2"
-          - "3.1.0"
-          - "3.0.2"
-    steps:
-      - uses: actions/checkout@v2
-      - run: make build-pure-on FISH_VERSION=${{ matrix.fish_version }}
-      - run: make test-pure-on FISH_VERSION=${{ matrix.fish_version }}
+  # test-container:
+  #   name: Test on fish ${{ matrix.fish_version }} on Docker
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       fish_version:
+  #         - "3.1.2"
+  #         - "3.1.0"
+  #         - "3.0.2"
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - run: make build-pure-on FISH_VERSION=${{ matrix.fish_version }}
+  #     - run: make test-pure-on FISH_VERSION=${{ matrix.fish_version }}
 
   test-macos:
     name: Test on fish on MacOS
     runs-on: macos-latest
     steps:
+      - uses: actions/checkout@v2
       - name: Install Fish
         run: brew install fish
       - name: Install Fisher > Fishtape > Pure
-        run: |
-          curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher jorgebucaran/fishtape ./
+        run: curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher jorgebucaran/fishtape ./
         shell: fish {0}
       - name: Test Pure
         run: fishtape tests/*.test.fish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,19 +2,53 @@ name: Run tests on CI
 on: [push, pull_request]
 
 jobs:
-  test:
-    name: Test on fish ${{ matrix.fish_version }}
+  test-ubuntu:
+    name: Test on fish on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Fish
+        run: |
+          sudo apt-add-repository -yn ppa:fish-shell/release-3
+          sudo apt-get update
+          sudo apt-get install -y fish
+      - name: Install Fisher > Fishtape > Pure
+        run: |
+          curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher
+          fisher install jorgebucaran/fishtape
+          fisher install ./
+        shell: fish {0}
+      - name: Test Pure
+        run: fishtape tests/*.test.fish
+        shell: fish {0}
+
+
+  test-container:
+    name: Test on fish ${{ matrix.fish_version }} on Docker
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        fish_version: [
-          "3.1.2",
-          "3.1.0",
-          "3.0.2",
-        ]
-      fail-fast: false
+        fish_version:
+          - "3.1.2"
+          - "3.1.0"
+          - "3.0.2"
     steps:
       - uses: actions/checkout@v2
       - run: make build-pure-on FISH_VERSION=${{ matrix.fish_version }}
       - run: make test-pure-on FISH_VERSION=${{ matrix.fish_version }}
+
+  test-macos:
+    name: Test on fish on MacOS
+    runs-on: macos-latest
+    steps:
+      - name: Install Fish
+        run: brew install fish
+      - name: Install Fisher > Fishtape > Pure
+        run: |
+          curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher
+          fisher install jorgebucaran/fishtape
+          fisher install ./
+        shell: fish {0}
+      - name: Test Pure
+        run: fishtape tests/*.test.fish
+        shell: fish {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,7 @@ jobs:
           sudo apt-get install -y fish
       - name: Install Fisher > Fishtape > Pure
         run: |
-          curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher
-          fisher install jorgebucaran/fishtape
-          fisher install ./
+          curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher jorgebucaran/fishtape ./
         shell: fish {0}
       - name: Test Pure
         run: fishtape tests/*.test.fish
@@ -45,9 +43,7 @@ jobs:
         run: brew install fish
       - name: Install Fisher > Fishtape > Pure
         run: |
-          curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher
-          fisher install jorgebucaran/fishtape
-          fisher install ./
+          curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher jorgebucaran/fishtape ./
         shell: fish {0}
       - name: Test Pure
         run: fishtape tests/*.test.fish


### PR DESCRIPTION
I'm exploring run test directly on a host MacOS and Ubuntu in Github CI in order to detect bug like #233.

### MacOS

```fish
fishtape tests/*.test.fish
  shell: /usr/local/bin/fish {0}
~/work/_temp/49efcf8a-08bd-4e62-bab2-92b45500538d (line 1): No matches for wildcard 'tests/*.test.fish'. See `help expand`.
fishtape tests/*.test.fish
         ^
Error: Process completed with exit code 124.
```

Glob works fine in Ubuntu or Docker/alpine environment.

### Ubuntu

Configure and runs the tests but a bunch are failing…