### PR TITLE
feat: add stash indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ source /tmp/pure_installer.fish; and install_pure
 - Display current directory tail ;
 - Display `git` branch name ;
   - Display `*` when `git` repository is _dirty_ ;
+  - Display `≡` when `git` repository is _stashed_ ;
   - Display `⇡` when branch is _ahead_ (commits to push) ;
   - Display `⇣` when branch is _behind_ (commits to pull) ;
 - Change `❯` to red when previous command has failed ;
@@ -78,7 +79,7 @@ or changing the defaults in your `config.fish`:
 
     _pure_set_default pure_show_system_time true
 
-#### Prompt Symbol
+### Prompt Symbol
 
 | Option                                 | Default | Description                                          |
 | :------------------------------------- | :------ | :--------------------------------------------------- |
@@ -90,7 +91,7 @@ or changing the defaults in your `config.fish`:
 | **`pure_symbol_title_bar_separator`**  | `—`     |
 :information_source:: Need [safer `git` symbols](https://github.com/sindresorhus/pure/wiki#safer-symbols)?
 
-#### Features
+### Features
 
 | Option                                         | Default | Description                                                                                     |
 | :--------------------------------------------- | :------ | :---------------------------------------------------------------------------------------------- |
@@ -103,33 +104,33 @@ or changing the defaults in your `config.fish`:
 | **`pure_reverse_prompt_symbol_in_vimode`**     | `true`  | `true`: `❮` indicate a non-insert mode.<br/>`false`: indicate vi mode with `[I]`, `[N]`, `[V]`. |
 | **`pure_check_for_new_release`**               | `false` | `true`: check repo for new release (on every shell start)                                       |
 
-#### Colors
+### Colors
 
 You can configure `pure` colors by changing the values of variables below. The value of these variables can be one of the colors accepted by the [`set_color`](https://fishshell.com/docs/current/commands.html#set_color) command (including various options like `--background`, `-o`, `--underline`, etc.):
 
-```
+```fish
 set pure_color_success 6638F0 --italics
 ```
 
 Variables regulating color for certain features from the second column can also accept one of the base color names:
 
-```
+```fish
 set pure_color_ssh_user_root pure_color_dark
 ```
 
 Take a note on the absence of `$` sign before the second argument in this case. By default all feature colors inherit their values from base colors.
 
-| Base Color               | Inherited by                                                                                                                                                                                    | Default   |
-| :----------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------- |
-| **`pure_color_primary`** | **`pure_color_current_directory`**                                                                                                                                                              | `blue`    |
-| **`pure_color_info`**    | **`pure_color_git_unpulled_commits`**<br>**`pure_color_git_unpushed_commits`**                                                                                                                  | `cyan`    |
-| **`pure_color_mute`**    | **`pure_color_git_branch`**<br>**`pure_color_git_dirty`**<br>**`pure_color_ssh_hostname`**<br>**`pure_color_ssh_separator`**<br>**`pure_color_ssh_user_normal`**<br>**`pure_color_virtualenv`** | `brblack` |
-| **`pure_color_success`** | **`pure_color_prompt_on_success`**                                                                                                                                                              | `magenta` |
-| **`pure_color_normal`**  | **`pure_color_jobs`**                                                                                                                                                                           | `normal`  |
-| **`pure_color_danger`**  | **`pure_color_prompt_on_error`**                                                                                                                                                                | `red`     |
-| **`pure_color_light`**   | **`pure_color_ssh_user_root`**                                                                                                                                                                  | `white`   |
-| **`pure_color_warning`** | **`pure_color_command_duration`**                                                                                                                                                               | `yellow`  |
-| **`pure_color_dark`**    |                                                                                                                                                                                                 | `black`   |
+| Base Color               | Inherited by                                                                                                                                                                                                                  | Default   |
+| :----------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------- |
+| **`pure_color_primary`** | **`pure_color_current_directory`**                                                                                                                                                                                            | `blue`    |
+| **`pure_color_info`**    | **`pure_color_git_unpulled_commits`**<br>**`pure_color_git_unpushed_commits`**                                                                                                                                                | `cyan`    |
+| **`pure_color_mute`**    | **`pure_color_git_branch`**<br>**`pure_color_git_dirty`**<br>**`pure_color_git_stash`**<br>**`pure_color_ssh_hostname`**<br>**`pure_color_ssh_separator`**<br>**`pure_color_ssh_user_normal`**<br>**`pure_color_virtualenv`** | `brblack` |
+| **`pure_color_success`** | **`pure_color_prompt_on_success`**                                                                                                                                                                                            | `magenta` |
+| **`pure_color_normal`**  | **`pure_color_jobs`**                                                                                                                                                                                                         | `normal`  |
+| **`pure_color_danger`**  | **`pure_color_prompt_on_error`**                                                                                                                                                                                              | `red`     |
+| **`pure_color_light`**   | **`pure_color_ssh_user_root`**                                                                                                                                                                                                | `white`   |
+| **`pure_color_warning`** | **`pure_color_command_duration`**                                                                                                                                                                                             | `yellow`  |
+| **`pure_color_dark`**    |                                                                                                                                                                                                                               | `black`   |
 
 ## :+1:  Contribute
 

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -1,4 +1,4 @@
-set --global pure_version 3.0.1 # used for bug report
+set --global pure_version 3.1.0 # used for bug report
 
 # Base colors
 _pure_set_default pure_color_primary blue

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -25,6 +25,7 @@ _pure_set_default pure_enable_git true
 _pure_set_default pure_symbol_git_unpulled_commits "⇣"
 _pure_set_default pure_symbol_git_unpushed_commits "⇡"
 _pure_set_default pure_symbol_git_dirty "*"
+_pure_set_default pure_symbol_git_stash "≡"
 _pure_set_default pure_color_git_unpulled_commits pure_color_info
 _pure_set_default pure_color_git_unpushed_commits pure_color_info
 _pure_set_default pure_color_git_branch pure_color_mute

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -13,7 +13,7 @@ _pure_set_default pure_color_dark black
 
 # Prompt
 _pure_set_default pure_symbol_prompt "❯"
-_pure_set_default pure_symbol_reverse_prompt "❮"  # used for VI mode
+_pure_set_default pure_symbol_reverse_prompt "❮" # used for VI mode
 _pure_set_default pure_color_prompt_on_error pure_color_danger
 _pure_set_default pure_color_prompt_on_success pure_color_success
 

--- a/functions/_pure_prompt_git.fish
+++ b/functions/_pure_prompt_git.fish
@@ -12,7 +12,7 @@ function _pure_prompt_git \
         set --local git_pending_commits (_pure_prompt_git_pending_commits)
 
         if test (_pure_string_width $git_pending_commits) -ne 0
-            set git_prompt $git_prompt $git_pending_commits
+            set --append git_prompt $git_pending_commits
         end
 
         echo $git_prompt

--- a/functions/_pure_prompt_git.fish
+++ b/functions/_pure_prompt_git.fish
@@ -8,7 +8,7 @@ function _pure_prompt_git \
     set --local is_git_repository (command git rev-parse --is-inside-work-tree 2>/dev/null)
 
     if test -n "$is_git_repository"
-        set --local git_prompt (_pure_prompt_git_branch)(_pure_prompt_git_dirty)
+        set --local git_prompt (_pure_prompt_git_branch)(_pure_prompt_git_dirty)(_pure_prompt_git_stash)
         set --local git_pending_commits (_pure_prompt_git_pending_commits)
 
         if test (_pure_string_width $git_pending_commits) -ne 0

--- a/functions/_pure_prompt_git_stash.fish
+++ b/functions/_pure_prompt_git_stash.fish
@@ -1,0 +1,16 @@
+function _pure_prompt_git_stash
+    set --local git_stash_symbol
+    set --local git_stash_color
+
+    set --local is_git_stash (
+        # Check if stashed files in a repo.
+        command git rev-list --walk-reflogs --count refs/stash >/dev/null 2>&1
+        and echo "true"
+    )
+    if test -n "$is_git_stash" # untracked or un-commited files
+        set git_stash_symbol "$pure_symbol_git_stash"
+        set git_stash_color (_pure_set_color $pure_color_git_stash)
+    end
+
+    echo "$git_stash_color$git_stash_symbol"
+end

--- a/functions/_pure_prompt_git_stash.fish
+++ b/functions/_pure_prompt_git_stash.fish
@@ -2,13 +2,12 @@ function _pure_prompt_git_stash
     set --local git_stash_symbol
     set --local git_stash_color
 
-    set --local is_git_stash (
-        # Check if stashed files in a repo.
+    set --local has_stashed_files (
         command git rev-list --walk-reflogs --count refs/stash >/dev/null 2>&1
         and echo "true"
     )
-    if test -n "$is_git_stash" # untracked or un-commited files
-        set git_stash_symbol "$pure_symbol_git_stash"
+    if test -n "$has_stashed_files" # untracked or un-commited files
+        set git_stash_symbol " $pure_symbol_git_stash"
         set git_stash_color (_pure_set_color $pure_color_git_stash)
     end
 

--- a/tests/_pure_parse_git_branch.test.fish
+++ b/tests/_pure_parse_git_branch.test.fish
@@ -32,5 +32,5 @@ end
 ) = 'master~1'
 
 function teardown
-    rm -r -f /tmp/test_pure_parse_git_branch
+    rm --force --recursive /tmp/test_pure_parse_git_branch
 end

--- a/tests/_pure_prompt_first_line.test.fish
+++ b/tests/_pure_prompt_first_line.test.fish
@@ -54,7 +54,7 @@ end
     set pure_begin_prompt_with_current_directory true
     _pure_prompt_first_line
 
-    rm -r -f /tmp/test
+    rm --force --recursive /tmp/test
 ) = '/tmp/test master user@hostname 1s'
 
 @test "_pure_prompt_first_line: print user@hostname (ssh-only), current directory, git, command duration" (
@@ -62,5 +62,5 @@ end
     set pure_begin_prompt_with_current_directory false
     _pure_prompt_first_line
 
-    rm -r -f /tmp/test
+    rm --force --recursive /tmp/test
 ) = 'user@hostname /tmp/test master 1s'

--- a/tests/_pure_prompt_git.test.fish
+++ b/tests/_pure_prompt_git.test.fish
@@ -4,6 +4,7 @@ source $current_dirname/../functions/_pure_prompt_git_branch.fish
 source $current_dirname/../functions/_pure_parse_git_branch.fish
 source $current_dirname/../functions/_pure_set_color.fish
 source $current_dirname/../functions/_pure_string_width.fish
+source $current_dirname/../functions/_pure_prompt_git_stash.fish
 
 
 function setup

--- a/tests/_pure_prompt_git_dirty.test.fish
+++ b/tests/_pure_prompt_git_dirty.test.fish
@@ -3,7 +3,7 @@ source $current_dirname/../functions/_pure_set_color.fish
 
 
 function setup
-    rm -r -f /tmp/pure_pure_prompt_git_dirty
+    rm --force --recursive /tmp/pure_pure_prompt_git_dirty
 
     mkdir -p /tmp/pure_pure_prompt_git_dirty
     cd /tmp/pure_pure_prompt_git_dirty
@@ -14,7 +14,7 @@ function setup
 end
 
 function teardown
-    rm -r -f /tmp/pure_pure_prompt_git_dirty
+    rm --force --recursive /tmp/pure_pure_prompt_git_dirty
 end
 
 @test "_pure_prompt_git_dirty: untracked files make git repo as dirty" (

--- a/tests/_pure_prompt_git_pending_commits.test.fish
+++ b/tests/_pure_prompt_git_pending_commits.test.fish
@@ -6,7 +6,7 @@ set fake_repo /tmp/pure
 set fake_remote /tmp/remote.git
 
 function setup
-    rm -r -f $fake_repo
+    rm --force --recursive $fake_repo
 
     git init --bare --quiet $fake_remote
     mkdir -p $fake_repo
@@ -21,7 +21,7 @@ function setup
 end
 
 function teardown
-    rm -r -f \
+    rm --force --recursive \
         $fake_repo \
         $fake_remote
 end
@@ -62,7 +62,7 @@ end
 @test "_pure_prompt_git_pending_commits: empty repo don't throw error" (
     set fake_empty_repo /tmp/empty-remote
     set fake_empty_remote /tmp/empty-remote.git
-    rm -r -f \
+    rm --force --recursive \
         $fake_empty_repo \
         $fake_empty_remote
     git init --bare --quiet $fake_empty_remote

--- a/tests/_pure_prompt_git_stash.test.fish
+++ b/tests/_pure_prompt_git_stash.test.fish
@@ -1,5 +1,6 @@
 source $current_dirname/../functions/_pure_prompt_git_stash.fish
 source $current_dirname/../functions/_pure_set_color.fish
+source $current_dirname/fixtures/constants.fish
 
 function setup
     rm --force --recursive /tmp/pure_pure_prompt_git_stash
@@ -16,13 +17,25 @@ function teardown
     rm --force --recursive /tmp/pure_pure_prompt_git_stash
 end
 
-@test "_pure_prompt_git_stash: check git stash indicator" (
-    touch file.txt
-    git add .
-    git stash
+@test "_pure_prompt_git_stash: no indicator when no stash" (
     set --global pure_symbol_git_stash '≡'
-    set --global pure_color_git_stash brblack
+    set --global pure_color_git_stash $EMPTY
+    touch init.file
+    git add init.file
+    git commit --quiet --message 'mandatory initial commit'
 
     _pure_prompt_git_stash
-) = (set_color brblack)'≡'
+) = $EMPTY
+
+@test "_pure_prompt_git_stash: stashing file shows indicator" (
+    set --global pure_symbol_git_stash '≡'
+    set --global pure_color_git_stash $EMPTY
+    touch init.file stash.file
+    git add init.file
+    git commit --quiet --message 'mandatory initial commit'
+    git add stash.file
+    git stash --quiet
+
+    _pure_prompt_git_stash
+) = '≡'
 

--- a/tests/_pure_prompt_git_stash.test.fish
+++ b/tests/_pure_prompt_git_stash.test.fish
@@ -2,7 +2,7 @@ source $current_dirname/../functions/_pure_prompt_git_stash.fish
 source $current_dirname/../functions/_pure_set_color.fish
 
 function setup
-    rm -r -f /tmp/pure_pure_prompt_git_stash
+    rm --force --recursive /tmp/pure_pure_prompt_git_stash
 
     mkdir -p /tmp/pure_pure_prompt_git_stash
     cd /tmp/pure_pure_prompt_git_stash
@@ -13,7 +13,7 @@ function setup
 end
 
 function teardown
-    rm -r -f /tmp/pure_pure_prompt_git_stash
+    rm --force --recursive /tmp/pure_pure_prompt_git_stash
 end
 
 @test "_pure_prompt_git_stash: check git stash indicator" (

--- a/tests/_pure_prompt_git_stash.test.fish
+++ b/tests/_pure_prompt_git_stash.test.fish
@@ -37,5 +37,5 @@ end
     git stash --quiet
 
     _pure_prompt_git_stash
-) = '≡'
+) = ' ≡'
 

--- a/tests/_pure_prompt_git_stash.test.fish
+++ b/tests/_pure_prompt_git_stash.test.fish
@@ -1,4 +1,4 @@
-source $current_dirname/../functions/_pure_prompt_git_stashed.fish
+source $current_dirname/../functions/_pure_prompt_git_stash.fish
 source $current_dirname/../functions/_pure_set_color.fish
 
 function setup

--- a/tests/_pure_prompt_git_stash.test.fish
+++ b/tests/_pure_prompt_git_stash.test.fish
@@ -1,0 +1,28 @@
+source $current_dirname/../functions/_pure_prompt_git_stashed.fish
+source $current_dirname/../functions/_pure_set_color.fish
+
+function setup
+    rm -r -f /tmp/pure_pure_prompt_git_stash
+
+    mkdir -p /tmp/pure_pure_prompt_git_stash
+    cd /tmp/pure_pure_prompt_git_stash
+
+    git init --quiet
+    git config --local user.email "you@example.com"
+    git config --local user.name "Your Name"
+end
+
+function teardown
+    rm -r -f /tmp/pure_pure_prompt_git_stash
+end
+
+@test "_pure_prompt_git_stash: check git stash indicator" (
+    touch file.txt
+    git add .
+    git stash
+    set --global pure_symbol_git_stash '≡'
+    set --global pure_color_git_stash brblack
+
+    _pure_prompt_git_stash
+) = (set_color brblack)'≡'
+


### PR DESCRIPTION
continuing #222 here as I don't have permission to push to fork.
closes #218, #222

---

### :rocket: Add stash indicator

Shows a symbol (`≡`) when there is stashed files, this is part of the `pure_enable_git` flag.

### :clap: Thanks

* @Arelav for his initial PR #222