### PR TITLE
Erase pure variables in uninstall handler

### DIFF
--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -72,3 +72,9 @@ _pure_set_default pure_symbol_title_bar_separator "—"
 
 # Check for new release on startup
 _pure_set_default pure_check_for_new_release false
+
+function _pure_uninstall --on-event pure_uninstall
+    set --names \
+        | string replace --filter --regex '(^_?pure)' 'set --erase $1' \
+        | source
+end


### PR DESCRIPTION
Pure doesn't erase its state after uninstalling. This PR adds an uninstall event handler to deal with that.