### PR TITLE
Change the default title bar separator to fix weird behavior on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ or changing the defaults in your `config.fish`:
 | **`pure_symbol_git_unpushed_commits`** | `⇡`     | Branch is ahead upstream (commits to push).          |
 | **`pure_symbol_prompt`**               | `❯`     | Prompt symbol.                                       |
 | **`pure_symbol_reverse_prompt`**       | `❮`     | VI non-insert mode symbol.                           |
-| **`pure_symbol_title_bar_separator`**  | `—`     |
+| **`pure_symbol_title_bar_separator`**  | `-`     |
 :information_source:: Need [safer `git` symbols](https://github.com/sindresorhus/pure/wiki#safer-symbols)?
 
 ### Features

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -69,7 +69,7 @@ _pure_set_default pure_color_command_duration pure_color_warning
 _pure_set_default pure_reverse_prompt_symbol_in_vimode true
 
 # Title
-_pure_set_default pure_symbol_title_bar_separator "—"
+_pure_set_default pure_symbol_title_bar_separator "-"
 
 # Check for new release on startup
 _pure_set_default pure_check_for_new_release false

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -1,4 +1,4 @@
-set --global pure_version 3.3.0 # used for bug report
+set --global pure_version 3.3.1 # used for bug report
 
 # Base colors
 _pure_set_default pure_color_primary blue

--- a/tests/_pure.test.fish
+++ b/tests/_pure.test.fish
@@ -48,7 +48,7 @@ source $current_dirname/../functions/_pure_set_default.fish
     set --erase pure_symbol_title_bar_separator
     source $current_dirname/../conf.d/pure.fish
     echo $pure_symbol_title_bar_separator
-) = "—"
+) = "-"
 
 @test "configure: pure_color_primary"  (
     set --erase pure_color_primary

--- a/tests/fish_title.test.fish
+++ b/tests/fish_title.test.fish
@@ -13,24 +13,24 @@ end
 if fish_version_at_least '3.0.0'
     @mesg (print_fish_version_at_least '3.0.0')
     @test "fish_title: contains current directory and previous command" (
-        set --global pure_symbol_title_bar_separator '—'
+        set --global pure_symbol_title_bar_separator '-'
         fish_title 'last-command'
-    ) = "directory: last-command — fish"
+    ) = "directory: last-command - fish"
 end
 
 if fish_version_at_least '3.0.0'
     @mesg (print_fish_version_at_least '3.0.0')
     @test "fish_title: contains current directory with an *empty* previous command" (
         fish_title ''
-    ) = "/tmp/current/directory — fish"
+    ) = "/tmp/current/directory - fish"
 end
 
 if fish_version_at_least '3.0.0'
     @mesg (print_fish_version_at_least '3.0.0')
     @test "fish_title: contains current path without a previous command" (
-        set --global pure_symbol_title_bar_separator '—'
+        set --global pure_symbol_title_bar_separator '-'
         fish_title
-    ) = "/tmp/current/directory — fish"
+    ) = "/tmp/current/directory - fish"
 end
 
 function teardown


### PR DESCRIPTION
Fixes #240.