### PR TITLE
Fix for #250

### DIFF
--- a/conf.d/_pure_init.fish
+++ b/conf.d/_pure_init.fish
@@ -7,4 +7,8 @@ set --global _pure_fresh_session true
 # Register `_pure_prompt_new_line` as an event handler fot `fish_prompt`
 functions --query _pure_prompt_new_line
 
-source (realpath (status --current-filename)/../../functions/_pure_uninstall.fish)
+function _pure_uninstall --on-event pure_uninstall
+    set --names \
+        | string replace --filter --regex '(^_?pure)' 'set --erase $1' \
+        | source
+end

--- a/conf.d/_pure_init.fish
+++ b/conf.d/_pure_init.fish
@@ -7,4 +7,4 @@ set --global _pure_fresh_session true
 # Register `_pure_prompt_new_line` as an event handler fot `fish_prompt`
 functions --query _pure_prompt_new_line
 
-source $__fish_config_dir/functions/_pure_uninstall.fish
+source (realpath (status --current-filename)/../../functions/_pure_uninstall.fish)

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -1,4 +1,4 @@
-set --global pure_version 3.3.4 # used for bug report
+set --global pure_version 3.3.5 # used for bug report
 
 # Base colors
 _pure_set_default pure_color_primary blue

--- a/functions/_pure_uninstall.fish
+++ b/functions/_pure_uninstall.fish
@@ -1,5 +1,0 @@
-function _pure_uninstall --on-event pure_uninstall
-    set --names \
-        | string replace --filter --regex '(^_?pure)' 'set --erase $1' \
-        | source
-end

--- a/tests/_pure_uninstall.test.fish
+++ b/tests/_pure_uninstall.test.fish
@@ -2,6 +2,6 @@ source $current_dirname/fixtures/constants.fish
 
 @test "init: source uninstall handler"  (
     functions --erase _pure_uninstall
-    source $current_dirname/../functions/_pure_uninstall.fish
+    source $current_dirname/../conf.d/_pure_init.fish
     functions --query _pure_uninstall
 ) $status -eq $SUCCESS


### PR DESCRIPTION
Source _pure_uninstall.fish using relative paths in the pure project rather than assuming pure is in $__fish_config_dir