### PR TITLE
use short format option for compatibility with macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest]
         fish_version: [
           "3.1.2",
           "3.1.0",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,23 +2,23 @@ name: Run tests on CI
 on: [push, pull_request]
 
 jobs:
-  test-ubuntu:
-    name: Test on fish on Ubuntu
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install Fish
-        run: |
-          sudo apt-add-repository -yn ppa:fish-shell/release-3
-          sudo apt-get update
-          sudo apt-get install -y fish
-      - name: Install Fisher > Fishtape > Pure
-        run: |
-          curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher jorgebucaran/fishtape ./
-        shell: fish {0}
-      - name: Test Pure
-        run: fishtape tests/*.test.fish
-        shell: fish {0}
+  # test-ubuntu:
+  #   name: Test on fish on Ubuntu
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install Fish
+  #       run: |
+  #         sudo apt-add-repository -yn ppa:fish-shell/release-3
+  #         sudo apt-get update
+  #         sudo apt-get install -y fish
+  #     - name: Install Fisher > Fishtape > Pure
+  #       run: |
+  #         curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher jorgebucaran/fishtape ./
+  #       shell: fish {0}
+  #     - name: Test Pure
+  #       run: fishtape tests/*.test.fish
+  #       shell: fish {0}
 
 
   test-container:
@@ -39,11 +39,11 @@ jobs:
     name: Test on fish on MacOS
     runs-on: macos-latest
     steps:
+      - uses: actions/checkout@v2
       - name: Install Fish
         run: brew install fish
       - name: Install Fisher > Fishtape > Pure
-        run: |
-          curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher jorgebucaran/fishtape ./
+        run: curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher jorgebucaran/fishtape ./
         shell: fish {0}
       - name: Test Pure
         run: fishtape tests/*.test.fish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,19 +2,53 @@ name: Run tests on CI
 on: [push, pull_request]
 
 jobs:
-  test:
-    name: Test on fish ${{ matrix.fish_version }}
+  test-ubuntu:
+    name: Test on fish on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Fish
+        run: |
+          sudo apt-add-repository -yn ppa:fish-shell/release-3
+          sudo apt-get update
+          sudo apt-get install -y fish
+      - name: Install Fisher > Fishtape > Pure
+        run: |
+          curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher
+          fisher install jorgebucaran/fishtape
+          fisher install ./
+        shell: fish {0}
+      - name: Test Pure
+        run: fishtape tests/*.test.fish
+        shell: fish {0}
+
+
+  test-container:
+    name: Test on fish ${{ matrix.fish_version }} on Docker
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        fish_version: [
-          "3.1.2",
-          "3.1.0",
-          "3.0.2",
-        ]
-      fail-fast: false
+        fish_version:
+          - "3.1.2"
+          - "3.1.0"
+          - "3.0.2"
     steps:
       - uses: actions/checkout@v2
       - run: make build-pure-on FISH_VERSION=${{ matrix.fish_version }}
       - run: make test-pure-on FISH_VERSION=${{ matrix.fish_version }}
+
+  test-macos:
+    name: Test on fish on MacOS
+    runs-on: macos-latest
+    steps:
+      - name: Install Fish
+        run: brew install fish
+      - name: Install Fisher > Fishtape > Pure
+        run: |
+          curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher
+          fisher install jorgebucaran/fishtape
+          fisher install ./
+        shell: fish {0}
+      - name: Test Pure
+        run: fishtape tests/*.test.fish
+        shell: fish {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,25 +2,6 @@ name: Run tests on CI
 on: [push, pull_request]
 
 jobs:
-  # test-ubuntu:
-  #   name: Test on fish on Ubuntu
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Install Fish
-  #       run: |
-  #         sudo apt-add-repository -yn ppa:fish-shell/release-3
-  #         sudo apt-get update
-  #         sudo apt-get install -y fish
-  #     - name: Install Fisher > Fishtape > Pure
-  #       run: |
-  #         curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher jorgebucaran/fishtape ./
-  #       shell: fish {0}
-  #     - name: Test Pure
-  #       run: fishtape tests/*.test.fish
-  #       shell: fish {0}
-
-
   test-container:
     name: Test on fish ${{ matrix.fish_version }} on Docker
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,7 @@ jobs:
           sudo apt-get install -y fish
       - name: Install Fisher > Fishtape > Pure
         run: |
-          curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher
-          fisher install jorgebucaran/fishtape
-          fisher install ./
+          curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher jorgebucaran/fishtape ./
         shell: fish {0}
       - name: Test Pure
         run: fishtape tests/*.test.fish
@@ -45,9 +43,7 @@ jobs:
         run: brew install fish
       - name: Install Fisher > Fishtape > Pure
         run: |
-          curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher
-          fisher install jorgebucaran/fishtape
-          fisher install ./
+          curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher jorgebucaran/fishtape ./
         shell: fish {0}
       - name: Test Pure
         run: fishtape tests/*.test.fish

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -1,4 +1,4 @@
-set --global pure_version 3.4.1 # used for bug report
+set --global pure_version 3.4.2 # used for bug report
 
 # Base colors
 _pure_set_default pure_color_primary blue

--- a/functions/_pure_prefix_root_prompt.fish
+++ b/functions/_pure_prefix_root_prompt.fish
@@ -1,5 +1,5 @@
 function _pure_prefix_root_prompt
-    set --local username (id --user --name) # current user name
+    set --local username (id -u -n) # current user name
     set --local prefix_root_prompt ''
 
     if test $pure_show_prefix_root_prompt = true -a "$username" = "root"

--- a/functions/_pure_prompt_ssh_user.fish
+++ b/functions/_pure_prompt_ssh_user.fish
@@ -1,5 +1,5 @@
 function _pure_prompt_ssh_user
-    set --local username (id --user --name) # current user name
+    set --local username (id -u -n) # current user name
     set --local username_color (_pure_set_color $pure_color_ssh_user_normal) # default color
 
     if test "$username" = "root"

--- a/functions/_pure_prompt_system_time.fish
+++ b/functions/_pure_prompt_system_time.fish
@@ -1,6 +1,6 @@
 function _pure_prompt_system_time --description "Display system time"
     if test $pure_show_system_time = true
         set --local time_color (_pure_set_color $pure_color_system_time)
-        echo "$time_color"(date +%T)
+        echo "$time_color"(date '+%T')
     end
 end

--- a/tests/_pure_parse_git_branch.test.fish
+++ b/tests/_pure_parse_git_branch.test.fish
@@ -32,5 +32,5 @@ end
 ) = 'master~1'
 
 function teardown
-    rm --force --recursive /tmp/test_pure_parse_git_branch
+    rm -rf /tmp/test_pure_parse_git_branch
 end

--- a/tests/_pure_prompt_current_folder.test.fish
+++ b/tests/_pure_prompt_current_folder.test.fish
@@ -12,6 +12,8 @@ source $current_dirname/../functions/_pure_set_color.fish
     set --global pure_color_current_directory $EMPTY
     set COLUMNS 20
     set current_prompt_width 10
+    mkdir -p /tmp/.pure;
+    and cd /tmp/.pure
 
     string length (_pure_prompt_current_folder "$current_prompt_width")
 ) = 8

--- a/tests/_pure_prompt_first_line.test.fish
+++ b/tests/_pure_prompt_first_line.test.fish
@@ -54,7 +54,7 @@ end
     set pure_begin_prompt_with_current_directory true
     _pure_prompt_first_line
 
-    rm --force --recursive /tmp/test
+    rm -rf /tmp/test
 ) = '/tmp/test master user@hostname 1s'
 
 @test "_pure_prompt_first_line: print user@hostname (ssh-only), current directory, git, command duration" (
@@ -62,5 +62,5 @@ end
     set pure_begin_prompt_with_current_directory false
     _pure_prompt_first_line
 
-    rm --force --recursive /tmp/test
+    rm -rf /tmp/test
 ) = 'user@hostname /tmp/test master 1s'

--- a/tests/_pure_prompt_git.test.fish
+++ b/tests/_pure_prompt_git.test.fish
@@ -13,7 +13,7 @@ function setup
 end
 
 function teardown
-    rm --force --recursive /tmp/test_pure_prompt_git
+    rm -rf /tmp/test_pure_prompt_git
 end
 
 @test "_pure_prompt_git: ignores directory that are not git repository" (

--- a/tests/_pure_prompt_git_branch.test.fish
+++ b/tests/_pure_prompt_git_branch.test.fish
@@ -13,7 +13,7 @@ function setup
 end
 
 function teardown
-    rm --force --recursive /tmp/test_pure_prompt_git_branch
+    rm -rf /tmp/test_pure_prompt_git_branch
 end
 
 @test "_pure_prompt_git_branch: show branch name in gray" (

--- a/tests/_pure_prompt_git_dirty.test.fish
+++ b/tests/_pure_prompt_git_dirty.test.fish
@@ -3,7 +3,7 @@ source $current_dirname/../functions/_pure_set_color.fish
 
 
 function setup
-    rm --force --recursive /tmp/pure_pure_prompt_git_dirty
+    rm -rf /tmp/pure_pure_prompt_git_dirty
 
     mkdir -p /tmp/pure_pure_prompt_git_dirty
     cd /tmp/pure_pure_prompt_git_dirty
@@ -14,7 +14,7 @@ function setup
 end
 
 function teardown
-    rm --force --recursive /tmp/pure_pure_prompt_git_dirty
+    rm -rf /tmp/pure_pure_prompt_git_dirty
 end
 
 @test "_pure_prompt_git_dirty: untracked files make git repo as dirty" (

--- a/tests/_pure_prompt_git_pending_commits.test.fish
+++ b/tests/_pure_prompt_git_pending_commits.test.fish
@@ -6,7 +6,7 @@ set fake_repo /tmp/pure
 set fake_remote /tmp/remote.git
 
 function setup
-    rm --force --recursive $fake_repo
+    rm -rf $fake_repo
 
     git init --bare --quiet $fake_remote
     mkdir -p $fake_repo
@@ -21,7 +21,7 @@ function setup
 end
 
 function teardown
-    rm --force --recursive \
+    rm -rf \
         $fake_repo \
         $fake_remote
 end
@@ -62,7 +62,7 @@ end
 @test "_pure_prompt_git_pending_commits: empty repo don't throw error" (
     set fake_empty_repo /tmp/empty-remote
     set fake_empty_remote /tmp/empty-remote.git
-    rm --force --recursive \
+    rm -rf \
         $fake_empty_repo \
         $fake_empty_remote
     git init --bare --quiet $fake_empty_remote

--- a/tests/_pure_prompt_git_stash.test.fish
+++ b/tests/_pure_prompt_git_stash.test.fish
@@ -3,7 +3,7 @@ source $current_dirname/../functions/_pure_set_color.fish
 source $current_dirname/fixtures/constants.fish
 
 function setup
-    rm --force --recursive /tmp/pure_pure_prompt_git_stash
+    rm -rf /tmp/pure_pure_prompt_git_stash
 
     mkdir -p /tmp/pure_pure_prompt_git_stash
     cd /tmp/pure_pure_prompt_git_stash
@@ -14,7 +14,7 @@ function setup
 end
 
 function teardown
-    rm --force --recursive /tmp/pure_pure_prompt_git_stash
+    rm -rf /tmp/pure_pure_prompt_git_stash
 end
 
 @test "_pure_prompt_git_stash: no indicator when no stash" (

--- a/tests/_pure_prompt_new_line.test.fish
+++ b/tests/_pure_prompt_new_line.test.fish
@@ -5,11 +5,11 @@ source $current_dirname/../functions/_pure_prompt_new_line.fish
 @test "_pure_prompt_new_line: print prompt with newline for existing session" (
     set _pure_fresh_session false
 
-    _pure_prompt_new_line | wc --lines
+    _pure_prompt_new_line | wc -l
 ) -eq $IS_PRESENT
 
 @test "_pure_prompt_new_line: print prompt without newline for new session" (
     set _pure_fresh_session true
 
-    _pure_prompt_new_line | wc --lines
+    _pure_prompt_new_line | wc -l
 ) = $NONE

--- a/tests/_pure_prompt_ssh_user.test.fish
+++ b/tests/_pure_prompt_ssh_user.test.fish
@@ -7,7 +7,7 @@ source $current_dirname/../functions/_pure_set_color.fish
 
     _pure_prompt_ssh_user
 
-) = (set_color green)(id --user --name)
+) = (set_color green)(id -u -n)
 
 @test "_pure_prompt_ssh_user: colorize root user" (
     function id; echo 'root'; end # mock

--- a/tests/_pure_prompt_system_time.test.fish
+++ b/tests/_pure_prompt_system_time.test.fish
@@ -12,7 +12,11 @@ function _pure_set_color; echo $EMPTY; end # drop coloring during test
 
 @test "_pure_prompt_system_time: displays system time when enable" (
     set --global pure_show_system_time true
-    function date; /bin/date --date='10:01:29' '+%T'; end
+    function date
+        test (uname) = Darwin;
+        and command date -j -f "%H:%M:%S" '10:01:29' '+%T'; # MacOS
+        or command date -d '10:01:29' '+%T'; # Linux
+    end
 
     _pure_prompt_system_time
 ) = '10:01:29'

--- a/tests/pure_tools_installer.test.fish
+++ b/tests/pure_tools_installer.test.fish
@@ -5,17 +5,17 @@ source $current_dirname/../tools/versions-compare.fish
 
 function remove_pure_files
     for file in $HOME/.config/fish/functions/_pure*.fish
-        rm --recursive --force "$file"
+        rm -rf "$file"
     end
     for file in $HOME/.config/fish/conf.d/*pure*
-        rm --recursive --force "$file"
+        rm -rf "$file"
     end
-    rm --recursive --force $HOME/.config/fish/functions/theme-pure
+    rm -rf $HOME/.config/fish/functions/theme-pure
 end
 
 function remove_fish_prompt_files
     for file in $HOME/.config/fish/functions/fish_*.fish
-        rm --recursive --force "$file"
+        rm -rf "$file"
     end
 end
 
@@ -156,7 +156,7 @@ end
 
 if test $USER = 'nemo'
     @test "installation methods: with OMF (Oh-My-Fish!)" (
-        rm --recursive --force $HOME/.local/share/omf $HOME/.config/omf/
+        rm -rf $HOME/.local/share/omf $HOME/.config/omf/
         curl --silent --location https://get.oh-my.fish > install
         and fish install --noninteractive >/dev/null
         set --global OMF_PURE_PATH $HOME/.local/share/omf/themes/pure
@@ -173,7 +173,7 @@ end
 
 if test $USER = 'nemo'
     @test "installation methods: with Fundle" (
-        rm --recursive --force $HOME/.config/fish/fundle/
+        rm -rf $HOME/.config/fish/fundle/
         mkdir -p $HOME/.config/fish/functions
         curl https://git.io/fundle --output $HOME/.config/fish/functions/fundle.fish --location --silent >/dev/null
 


### PR DESCRIPTION
fixes #258 #260

---

- use short format option for compatibility with macOS
- bump version 3.4.2
- run CI on latest Ubuntu and MacOS
- run CI directly on Ubuntu MacOS plus inside containers
- inline fisher install as recommended by jorge bucaran
- checkout code before running MacOS job
- remove ubuntu job (for now)
