### PR TITLE
nixshell: implement `nix shell` support

### DIFF
--- a/functions/_pure_prompt.fish
+++ b/functions/_pure_prompt.fish
@@ -3,7 +3,7 @@ function _pure_prompt \
     --argument-names exit_code
 
     set --local jobs (_pure_prompt_jobs)
-    set --local nixdevshell (_pure_prompt_nixdevshell) # Nix build environment indicator
+    set --local nixdevshell (_pure_prompt_nixdevshell) # Nix shell indicator
     set --local virtualenv (_pure_prompt_virtualenv) # Python virtualenv name
     set --local aws_profile (_pure_prompt_aws_profile) # AWS profile name
     set --local vimode_indicator (_pure_prompt_vimode) # vi-mode indicator

--- a/functions/_pure_prompt_nixdevshell.fish
+++ b/functions/_pure_prompt_nixdevshell.fish
@@ -1,13 +1,17 @@
 function _pure_prompt_nixdevshell \
-    --description "Indicate if nix develop shell is activated"
+    --description "Indicate if a nix shell is activated"
 
     if set --query pure_enable_nixdevshell;
-        and test "$pure_enable_nixdevshell" = true;
-        and test -n "$IN_NIX_SHELL"
+        and test "$pure_enable_nixdevshell" = true
 
-        set --local prefix (_pure_set_color $pure_color_nixdevshell_prefix)$pure_symbol_nixdevshell_prefix
-        set --local symbol (_pure_set_color $pure_color_nixdevshell_status)$IN_NIX_SHELL
+        set --local shell_type (_pure_prompt_nixdevshell_type)
 
-        echo "$prefix$symbol"
+        if test -n "$shell_type"
+
+            set --local prefix (_pure_set_color $pure_color_nixdevshell_prefix)$pure_symbol_nixdevshell_prefix
+            set --local symbol (_pure_set_color $pure_color_nixdevshell_status)$shell_type
+
+            echo "$prefix$symbol"
+        end
     end
 end

--- a/functions/_pure_prompt_nixdevshell_type.fish
+++ b/functions/_pure_prompt_nixdevshell_type.fish
@@ -1,0 +1,10 @@
+function _pure_prompt_nixdevshell_type \
+    --description "Indicates the nix shell type" # Ported from starship project ❤️ https://github.com/starship/starship/blob/9ab8b84ea6cd40f83a34836111c6bda2203dccfe/src/modules/nix_shell.rs#L15-L40
+
+    if set --query IN_NIX_SHELL
+        echo $IN_NIX_SHELL
+    else if string match --regex --quiet -- "/nix/store" $PATH
+        # glob pattern seems to be broken in fish?, therefore using regex
+        echo unknown
+    end
+end

--- a/tests/_pure_prompt_nixdevshell.test.fish
+++ b/tests/_pure_prompt_nixdevshell.test.fish
@@ -1,5 +1,6 @@
 source (status dirname)/fixtures/constants.fish
 source (status dirname)/../functions/_pure_prompt_nixdevshell.fish
+source (status dirname)/../functions/_pure_prompt_nixdevshell_type.fish
 @echo (_print_filename (status filename))
 
 function before_each
@@ -22,7 +23,12 @@ before_each
     set --universal pure_enable_nixdevshell true
     set --erase IN_NIX_SHELL
 
-    _pure_prompt_nixdevshell
+    # when executing the tests in nixos builds, /nix/store paths are in the $PATH variable
+    begin
+        set --local --export PATH /bin/bash
+
+        _pure_prompt_nixdevshell
+    end
 ) $status -eq $SUCCESS
 
 before_each
@@ -33,3 +39,24 @@ before_each
 
     _pure_prompt_nixdevshell
 ) = "󱄅 pure"
+
+before_each
+@test "_pure_prompt_nixdevshell: show prompt and status inside nix dev shell" (
+    set --universal pure_enable_nixdevshell true
+    set --universal pure_symbol_nixdevshell_prefix "󱄅 "
+    set IN_NIX_SHELL impure
+
+    _pure_prompt_nixdevshell
+) = "󱄅 impure"
+
+before_each
+@test "_pure_prompt_nixdevshell: show prompt and status inside nix shell" (
+    set --universal pure_enable_nixdevshell true
+    set --universal pure_symbol_nixdevshell_prefix "󱄅 "
+
+    begin
+        set --local --export PATH /nix/store/lz9gfg6iybsh0hiignpk55w99a3bj4vb-hello-2.12.1/bin:/bin
+
+        _pure_prompt_nixdevshell
+    end
+) = "󱄅 unknown"


### PR DESCRIPTION
**related:** #355

Adds support for indicating presence of nix-shell, nix shell and nix develop.

nix-shell impure:
![image](https://github.com/user-attachments/assets/aecd9dfc-a953-4e75-aff0-5195e367df9e)

nix-shell pure:
![image](https://github.com/user-attachments/assets/eeec053b-3c7e-4bc9-87b7-96769a113f0f)

nix shell:
![image](https://github.com/user-attachments/assets/ca9231c5-7198-4b2c-9b4d-5416eb37ea55)

nix develop:
![image](https://github.com/user-attachments/assets/d7803287-5805-4e89-9b0b-ebf64413ea5f)



## Acceptance Checks

* [x] Documentation is up-to-date:
  * [ ] Add entry in _feature list_ of [README.md][README] ;
  * [ ] Add entry in _features' overview_ in [docs/][features-overview]  ;
  * [ ] Add section in [feature list][features-list] to document
    * [ ] Features' flag ;
    * [ ] Prompt symbol ;
* [ ] Default are defined in [`conf.d/pure.fish`][default] for:
  * [ ] Feature flag ;
  * [ ] Symbol ;
* [x] Tests are passing (I can help you :hugs: ):
  * [ ] Config are tested (cf. [tests/_pure.test.fish][config-test]) ;
  * [x] Feature is tested in `tests/feature_name.test.fish` ;
* [ ] Customization is available ;
* [x] Feature is implemented.

[default]: /pure-fish/pure/blob/master/conf.d/pure.fish
[config-test]: /pure-fish/pure/blob/master/tests/_pure.test.fish
[contributing]: /pure-fish/pure/blob/master/CONTRIBUTING.md
[features-overview]: /pure-fish/pure/blob/master/docs/components/features-overview.md
[README]: /pure-fish/pure/blob/master/README.md
[features-list]: /pure-fish/pure/blob/master/docs/components/features-list.md
