### PR TITLE
fix(fisher,update): being polite by citing old version

### DIFF
--- a/conf.d/_pure_init.fish
+++ b/conf.d/_pure_init.fish
@@ -18,7 +18,7 @@ function _pure \
 end
 
 function _pure_install --on-event pure_install \
-    --description 'Fisher handler to install pure prompt'
+    --description 'Fisher handler when pure prompt is installed'
     
     source $__fish_config_dir/conf.d/pure.fish
     
@@ -27,8 +27,11 @@ function _pure_install --on-event pure_install \
         (set_color --bold $pure_color_success)$pure_version(set_color normal)
 end
 
-function _pure_update --on-event pure_update \
-    --description 'Fisher handler to update pure prompt'
+# Fisher emit an event for all files under conf.d/. 
+# We listen to the event when the new conf.d/_pure_init.fish is sourced,
+# to read old `pure_version` before sourcing conf.d/pure.fish happens.
+function _pure_update --on-event _pure_init_update \
+    --description 'Fisher handler pure prompt is updated'
     
     set --local previous_version $pure_version
     source $__fish_config_dir/conf.d/pure.fish
@@ -40,7 +43,7 @@ function _pure_update --on-event pure_update \
 end
 
 function _pure_uninstall --on-event pure_uninstall \
-    --description 'Fisher handler to uninstall pure prompt'
+    --description 'Fisher handler pure prompt is uninstalled'
 
     rm -f $__fish_config_dir/conf.d/pure.fish
 

--- a/tests/_pure_update.test.fish
+++ b/tests/_pure_update.test.fish
@@ -32,3 +32,13 @@ before_each
 
     _pure_update | strip_ansi
 ) = "Updating: ❯❮❯ pure 1.0.0 → 2.0.0"
+
+before_each
+@test "init/_pure_update: `_pure_update` run when `_pure_init_update` event is emitted" (
+    set --global pure_version 1.0.0 # current version
+    source (status dirname)/../conf.d/_pure_init.fish
+    echo "set --global pure_version 2.0.0 # new version" > $__fish_config_dir/conf.d/pure.fish
+
+    emit _pure_init_update # due to this event, test output will display: Updating: ❯❮❯ pure 1.0.0 → 2.0.0
+    echo $pure_version
+) = '2.0.0'


### PR DESCRIPTION
Change event we listen to so we can source the old $pure_version
before it's overriden
