### PR TITLE
docs: fix typos and grammar across documentation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -43,7 +43,7 @@ _pure_set_default pure_symbol_foo_feature "🤯"
   * [ ] Feature flag ;
   * [ ] Symbol ;
 * [ ] Tests are passing (we can help you :hugs: ):
-  * [ ] Config are tested (cf. [tests/_pure.test.fish][config-test]) ;
+  * [ ] Configs are tested (cf. [tests/_pure.test.fish][config-test]) ;
   * [ ] Feature is tested in `tests/feature_name.test.fish` ;
 * [ ] Customization is available ;
 * [ ] Feature is implemented.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
 ## Code of Conduct
 
 * Be kind to others ;
-* Critic code not people.
+* Critique code not people.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Specify the [`FISH_VERSION`][fish-releases] you want, and the `CMD` executed by 
 
 ### Be Fishy
 
-Use the idiomatic [`test` instead of `[`](httpsc://fishshell.com/docs/current/commands.html#test) brackets (as recommended by the documentation).
+Use the idiomatic [`test` instead of `[`](https://fishshell.com/docs/current/commands.html#test) brackets (as recommended by the documentation).
 
 ### Be Explicit
 
@@ -60,7 +60,7 @@ Use the idiomatic [`test` instead of `[`](httpsc://fishshell.com/docs/current/co
 
 ### Local and Tools
 
-> No need to use namespace when your variable variable is declare locally (`set --local`) or your file/test file is related to tooling (_installer.fish_, testing package managers install).
+> No need to use namespace when your variable is declared locally (`set --local`) or your file/test file is related to tooling (_installer.fish_, testing package managers install).
 
 * Filename: `my_tool.fish`
 * Test file: `my_tool.test.fish`
@@ -133,7 +133,7 @@ $pure_color_git_unpulled_commits
 > Name should follow `$pure_<verb>_<feature>` pattern, where:
 >
   > * `verb` describe the action triggered by the feature (_i.e._ `separate`, `begin`, `show`, etc.) ;
-  > * `feature` descibre the _what_ of the feature (_i.e._ `prompt_on_error`, `with_current_directory`, `git_status`, etc.).
+  > * `feature` describe the _what_ of the feature (_i.e._ `prompt_on_error`, `with_current_directory`, `git_status`, etc.).
 > Value should be **a boolean**.
   
 #### Example

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Fully **customizable** (colors, symbols and features):
 * [Detect when running in a container (e.g. `docker`, `podman`, `LXC`/`LXD`) 🏴🛠][container-detection-docker]
 * [Indicate if a `nix develop` shell is activated 🏴🛠][nix-os].
 * [Show system time 🏴][time-duration] ;
-* [Transient prompt mode simplify previous prompts 🏴][transient-prompt] ;
+* [Transient prompt mode simplifies previous prompts 🏴][transient-prompt] ;
 * [Show number of running jobs 🏴][jobs] ;
 * [Prefix when `root` 🏴🛠][working-as-root] ;
 * [Display `git` branch name 🏴🛠][git] ;
@@ -65,7 +65,7 @@ Fully **customizable** (colors, symbols and features):
 * [Shorten or truncate _current folder_ component 🏴🛠][current-working-directory] ;
 * and more…
 
-🏴 means it's controlled by a feature flag, 🛠 mean it's configurable.
+🏴 means it's controlled by a feature flag, 🛠 means it's configurable.
 
 ## Configuration
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -45,7 +45,7 @@ toc_depth: 3
 ### What's Changed
 * feat/show version on install update by @edouard-lopez in https://github.com/pure-fish/pure/pull/390
 
-We do our best to clean up after ourselves and provides information on the version installed or updated.
+We do our best to clean up after ourselves and provide information on the version installed or updated.
 
 #### Plugin Fresh Install
 

--- a/docs/components/features-list.md
+++ b/docs/components/features-list.md
@@ -12,8 +12,8 @@
 
 !!! success "🐌 Faster Prompt"
 
-    Checking new release send a HTTP request that slow down your prompt rendering
-    as it wait for remote server response. Set it to `false` speed up rendering:
+    Checking new release sends an HTTP request that slows down your prompt rendering
+    as it waits for remote server response. Set it to `false` to speed up rendering:
 
     ```fish
     set --universal pure_check_for_new_release false

--- a/docs/components/features-overview.md
+++ b/docs/components/features-overview.md
@@ -20,7 +20,7 @@ Fully **customizable** (colors, symbols and features):
 * [Detect when running in a container (e.g. `docker`, `podman`, `LXC`/`LXD`) 🏴🛠][container-detection-docker]
 * [Indicate if a `nix develop` shell is activated 🏴🛠][nix-os].
 * [Show system time 🏴][time-duration] ;
-* [Transient prompt mode simplify previous prompts 🏴][transient-prompt] ;
+* [Transient prompt mode simplifies previous prompts 🏴][transient-prompt] ;
 * [Show number of running jobs 🏴][jobs] ;
 * [Prefix when `root` 🏴🛠][working-as-root] ;
 * [Display `git` branch name 🏴🛠][git] ;
@@ -36,7 +36,7 @@ Fully **customizable** (colors, symbols and features):
 * [Shorten or truncate _current folder_ component 🏴🛠][current-working-directory] ;
 * and more…
 
-🏴 means it's controlled by a feature flag, 🛠 mean it's configurable.
+🏴 means it's controlled by a feature flag, 🛠 means it's configurable.
 
 [async]: https://github.com/pure-fish/pure/wiki/Async-git-Prompt
 <!-- markdownlint-disable MD051 -->

--- a/docs/components/troubleshooting.md
+++ b/docs/components/troubleshooting.md
@@ -36,7 +36,7 @@ To configure your Fish's greeting, edit `$__fish_config_dir/functions/fish_greet
 
 ### Install and Update
 
-We do our best to clean up after ourselfves and provides information on the version installed or updated.
+We do our best to clean up after ourselves and provide information on the version installed or updated.
 
 === "Fresh Install"
 

--- a/functions/_pure_prompt_git.fish
+++ b/functions/_pure_prompt_git.fish
@@ -1,5 +1,5 @@
 function _pure_prompt_git \
-    --description 'Print git repository informations: branch name, dirty, upstream ahead/behind'
+    --description 'Print git repository information: branch name, dirty, upstream ahead/behind'
 
     set ABORT_FEATURE 2
 


### PR DESCRIPTION
**related:** N/A (housekeeping)

## Summary

Fix typos, broken links, and grammar errors across 9 files:

- **Broken URL:** `httpsc://` → `https://` in CONTRIBUTING.md
- **Typos:** `descibre` → `describe`, `ourselfves` → `ourselves`, `informations` → `information`
- **Duplicate word:** `variable variable` → `variable`
- **Subject-verb agreement:** `mean` → `means`, `simplify` → `simplifies`, `send` → `sends`, `slow down` → `slows down`, `wait` → `waits`, `provides` → `provide`, `are` → `is`
- **Wrong word:** `Critic` → `Critique`

## Acceptance Checks

* [x] Documentation is up-to-date
* [x] Tests are passing (docs-only change, no behavior changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)