### PR TITLE
ci: skip docs deployment on pull requests

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -47,6 +47,7 @@ jobs:
         run: make update-changelog
 
       - name: Deploy docs
+        if: github.event_name != 'pull_request'
         uses: mhausenblas/mkdocs-deploy-gh-pages@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**related:** fixes #406

## Summary

The `Deploy docs` step in the `doc.yml` workflow runs on `pull_request` events, but `github-actions[bot]` lacks push permissions to the `gh-pages` branch on PRs, causing it to fail with a 403 error.

Added an `if: github.event_name != 'pull_request'` condition to the deploy step so it only runs on `push` (to master), `workflow_call`, and `workflow_dispatch` events.

## Acceptance Checks

* [x] CI workflow updated
* [x] Docs still deploy on push to master, workflow_call, and workflow_dispatch
* [x] PR builds skip the deploy step, avoiding the permission error

🤖 Generated with [Claude Code](https://claude.com/claude-code)