### PR TITLE
ci: always generate screenshots before deploying docs

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -29,18 +29,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Check if screenshot.fish changed
-        id: screenshot-changed
-        uses: tj-actions/changed-files@v45
-        with:
-          files: tools/screenshot.fish
-
       - name: Prepare screenshot image
-        if: steps.screenshot-changed.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch'
         run: make build-pure-screenshot FISH_VERSION=${{ inputs.fish_version || '4.0.2' }}
 
       - name: Take screenshot
-        if: steps.screenshot-changed.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch'
         run: make run-pure-screenshot FISH_VERSION=${{ inputs.fish_version || '4.0.2' }}
 
       - name: Update changelog using releases notes


### PR DESCRIPTION
## Summary

All screenshot images on the documentation site return 404 (e.g. [this one](https://pure-fish.github.io/pure/assets/screenshots/mirage-pure_begin_prompt_with_current_directory%3Dtrue.png)).

The screenshot `.png` files are not committed to the repo — they're generated at build time by `tools/screenshot.fish` running in Docker. However, the generation steps in the docs workflow were conditional: they only ran when `tools/screenshot.fish` itself had changed (via `tj-actions/changed-files`) or on manual `workflow_dispatch`. On every other docs deployment, the screenshots were skipped, resulting in a site with no images.

This PR removes the conditional checks so screenshots are always generated before MkDocs deploys the site.

## Test plan

- [x] Verified locally: ran `make build-pure-screenshot` and `make run-pure-screenshot` followed by `make serve-pure-doc` — all 84 screenshots (42 configs × light/mirage) generated successfully and rendered on the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)