### PR TITLE
Simplify git dirty check using git status

### DIFF
--- a/docs/components/features-list.md
+++ b/docs/components/features-list.md
@@ -77,6 +77,10 @@
 | **`pure_symbol_git_unpushed_commits`** | `⇡`     | Branch is ahead upstream (commits to push).          |
 | **`pure_show_numbered_git_indicator`** | `false` | Show number of git stash and commits behind/ahead    |
 
+!!! tip "Large repositories"
+
+    If your prompt feels slow in a large Git repository, see the [Troubleshooting section on large repositories](#large-git-repositories).
+
 > :information_source: Need [safer `git` symbols](https://github.com/sindresorhus/pure/wiki/Customizations,-hacks-and-tweaks#safer-symbols)?
 
 === "Enabled (with `git`)"

--- a/docs/components/troubleshooting.md
+++ b/docs/components/troubleshooting.md
@@ -53,6 +53,20 @@ We do our best to clean up after ourselves and provide information on the versio
 We support installing pure into a folder other than `__fish_config_dir`. Updates and uninstallation will work normally
 even when not installed into `__fish_config_dir`.
 
+### Slowness: try disabling `status.showUntrackedFiles`
+
+!!! info
+
+    In large repositories, checking for untracked files can significantly slow down the prompt.
+
+Git's `status.showUntrackedFiles` option controls whether untracked files are listed. Setting it to `false` in large repositories improves `git status` performance, and Pure respects this setting when checking for dirty state:
+
+```fish
+git config status.showUntrackedFiles false
+```
+
+This can reduce dirty-check times from several seconds to under a second in large repositories.
+
 ### Slowness: try Async `git` Prompt
 
 !!! info

--- a/functions/_pure_prompt_git_dirty.fish
+++ b/functions/_pure_prompt_git_dirty.fish
@@ -3,19 +3,10 @@ function _pure_prompt_git_dirty
     set --local git_dirty_color
 
     set --local is_git_dirty (
-        # HEAD may not exist (e.g. immediately after git init); diff-index is
-        # fast for staged checks but requires a ref.
-        #
-        # The diff-index (or diff --staged) checks for staged changes; the diff
-        # checks for unstaged changes; the ls-files checks for untracked files.
-        # We put them in this order because checking staged changes is *fast*.
-        if command git rev-list --max-count=1 HEAD -- >/dev/null 2>&1;
-            not command git diff-index --ignore-submodules --cached --quiet HEAD -- >/dev/null 2>&1;
-        else;
-            not command git diff --staged --ignore-submodules --no-ext-diff --quiet --exit-code >/dev/null 2>&1;
-        end
-        or not command git diff --ignore-submodules --no-ext-diff --quiet --exit-code >/dev/null 2>&1
-        or command git ls-files --others --exclude-standard --directory --no-empty-directory --error-unmatch -- ':/*' >/dev/null 2>&1
+        # Single git status call that respects status.showUntrackedFiles config.
+        # Set `git config status.showUntrackedFiles no` in large repos to skip
+        # the expensive untracked-files scan.
+        test -n "$(command git status --porcelain --ignore-submodules 2>/dev/null)"
         and echo "true"
     )
     if test -n "$is_git_dirty"  # untracked or un-commited files


### PR DESCRIPTION
In large repositories, checking for untracked files is very slow, so `status.showUntrackedFiles=false` is typically set to improve `git status` performance.

`_pure_prompt_git_dirty` doesn't use `git status` however, but three separate `git` commands to check for staged changes, unstaged changes and untracked files. The command for untracked files is `git ls-files --others` which doesn't respect `status.showUntrackedFiles=false`.

Instead we can check for non-empty output from `git status --porcelain`, which checks all three of these things in one command and respects `status.showUntrackedFiles=false`.

This reduces `_pure_prompt_git_dirtry` runtime from 9.3s to 0.8s on our repository.

