### PR TITLE
feat: `pure_12hr_system_time` option for 12 hour system time

### DIFF
--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -47,7 +47,7 @@ _pure_set_default pure_color_jobs pure_color_normal
 
 # Show system time
 _pure_set_default pure_show_system_time false
-_pure_set_default pure_12hr_system_time false
+_pure_set_default pure_system_time_format '+%T' # 12 hour time: '+%I:%M:%S %p'
 _pure_set_default pure_color_system_time pure_color_mute
 
 # Nix build environment

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -47,6 +47,7 @@ _pure_set_default pure_color_jobs pure_color_normal
 
 # Show system time
 _pure_set_default pure_show_system_time false
+_pure_set_default pure_12hr_system_time false
 _pure_set_default pure_color_system_time pure_color_mute
 
 # Nix build environment

--- a/docs/components/features-list.md
+++ b/docs/components/features-list.md
@@ -279,7 +279,7 @@
 | Option                                     | Default | Description                                                         |
 | :----------------------------------------- | :------ | :------------------------------------------------------------------ |
 | **`pure_show_system_time`**                | `false` | `true`: shows system time before the prompt symbol (as `%H:%M:%S`). |
-| **`pure_12hr_system_time`**                | `false` | `true`: shows system time in 12-hour time instead of 24-hour time.  |
+| **`pure_system_time_format`**              | `+%T`   | `true`: shows system time in 12-hour time instead of 24-hour time.  |
 
 === "Show system time (enabled)"
 

--- a/docs/components/features-list.md
+++ b/docs/components/features-list.md
@@ -279,6 +279,7 @@
 | Option                                     | Default | Description                                                         |
 | :----------------------------------------- | :------ | :------------------------------------------------------------------ |
 | **`pure_show_system_time`**                | `false` | `true`: shows system time before the prompt symbol (as `%H:%M:%S`). |
+| **`pure_12hr_system_time`**                | `false` | `true`: shows system time in 12-hour time instead of 24-hour time.  |
 
 === "Show system time (enabled)"
 

--- a/functions/_pure_prompt_system_time.fish
+++ b/functions/_pure_prompt_system_time.fish
@@ -1,10 +1,6 @@
 function _pure_prompt_system_time --description "Display system time"
     if set --query pure_show_system_time; and test "$pure_show_system_time" = true
         set --local time_color (_pure_set_color $pure_color_system_time)
-        if set --query pure_system_time_format
-            echo "$time_color"(date $pure_system_time_format)
-        else
-            echo "$time_color"(date '+%T')
-        end
+        echo "$time_color"(date $pure_system_time_format)
     end
 end

--- a/functions/_pure_prompt_system_time.fish
+++ b/functions/_pure_prompt_system_time.fish
@@ -1,8 +1,8 @@
 function _pure_prompt_system_time --description "Display system time"
     if set --query pure_show_system_time; and test "$pure_show_system_time" = true
         set --local time_color (_pure_set_color $pure_color_system_time)
-        if set --query pure_12hr_system_time; and test "$pure_12hr_system_time" = true
-            echo "$time_color"(date '+%I:%M:%S %p')
+        if set --query pure_system_time_format
+            echo "$time_color"(date $pure_system_time_format)
         else
             echo "$time_color"(date '+%T')
         end

--- a/functions/_pure_prompt_system_time.fish
+++ b/functions/_pure_prompt_system_time.fish
@@ -1,6 +1,10 @@
 function _pure_prompt_system_time --description "Display system time"
     if set --query pure_show_system_time; and test "$pure_show_system_time" = true
         set --local time_color (_pure_set_color $pure_color_system_time)
-        echo "$time_color"(date '+%T')
+        if set --query pure_12hr_system_time; and test "$pure_12hr_system_time" = true
+            echo "$time_color"(date '+%I:%M:%S %p')
+        else
+            echo "$time_color"(date '+%T')
+        end
     end
 end

--- a/tests/_pure_prompt_system_time.test.fish
+++ b/tests/_pure_prompt_system_time.test.fish
@@ -27,9 +27,9 @@ before_all
     _pure_prompt_system_time
 ) = '10:01:29'
 
-@test "_pure_prompt_system_time: displays 12hr system time when pure_12hr_system_time enabled" (
+@test "_pure_prompt_system_time: displays 12hr system time when pure_system_time_format set to 12hr" (
     set --universal pure_show_system_time true
-    set --universal pure_12hr_system_time true
+    set --universal pure_system_time_format '+%I:%M:%S %p'
     function date
         test (uname) = Darwin;
         and command date -j -f "%H:%M:%S" '22:01:29' '+%I:%M:%S %p'; # MacOS
@@ -39,9 +39,9 @@ before_all
     _pure_prompt_system_time
 ) = '10:01:29 PM'
 
-@test "_pure_prompt_system_time: displays 24hr system time when pure_12hr_system_time disabled" (
+@test "_pure_prompt_system_time: displays 24hr system time when pure_system_time_format set to default" (
     set --universal pure_show_system_time true
-    set --universal pure_12hr_system_time false
+    set --universal pure_system_time_format '+%T'
     function date
         test (uname) = Darwin;
         and command date -j -f "%H:%M:%S" '10:01:29' '+%T'; # MacOS

--- a/tests/_pure_prompt_system_time.test.fish
+++ b/tests/_pure_prompt_system_time.test.fish
@@ -26,3 +26,27 @@ before_all
 
     _pure_prompt_system_time
 ) = '10:01:29'
+
+@test "_pure_prompt_system_time: displays 12hr system time when pure_12hr_system_time enabled" (
+    set --universal pure_show_system_time true
+    set --universal pure_12hr_system_time true
+    function date
+        test (uname) = Darwin;
+        and command date -j -f "%H:%M:%S" '22:01:29' '+%I:%M:%S %p'; # MacOS
+        or command date -d '22:01:29' '+%I:%M:%S %p'; # Linux
+    end
+
+    _pure_prompt_system_time
+) = '10:01:29 PM'
+
+@test "_pure_prompt_system_time: displays 24hr system time when pure_12hr_system_time disabled" (
+    set --universal pure_show_system_time true
+    set --universal pure_12hr_system_time false
+    function date
+        test (uname) = Darwin;
+        and command date -j -f "%H:%M:%S" '10:01:29' '+%T'; # MacOS
+        or command date -d '10:01:29' '+%T'; # Linux
+    end
+
+    _pure_prompt_system_time
+) = '10:01:29'

--- a/tests/_pure_prompt_system_time.test.fish
+++ b/tests/_pure_prompt_system_time.test.fish
@@ -44,9 +44,9 @@ before_all
     set --universal pure_system_time_format '+%T'
     function date
         test (uname) = Darwin;
-        and command date -j -f "%H:%M:%S" '10:01:29' '+%T'; # MacOS
-        or command date -d '10:01:29' '+%T'; # Linux
+        and command date -j -f "%H:%M:%S" '22:01:29' '+%T'; # MacOS
+        or command date -d '22:01:29' '+%T'; # Linux
     end
 
     _pure_prompt_system_time
-) = '10:01:29'
+) = '22:01:29'


### PR DESCRIPTION
## Specs

12 hour system time, if system time is enabled

### New config in `conf.d/pure.fish`

```fish
_pure_set_default pure_12hr_system_time false
```
<!-- remove if necessary -->

### Documentation

#### Usage

```shell
❯ set --universal pure_12hr_system_time true
```

## Acceptance Checks

* [x] Documentation is up-to-date:
  * [x] Add entry in _feature list_ of [README.md][README] ;
  * [ ] Add entry in _features' overview_ in [docs/][features-overview]  ;
  * [x] Add section in [feature list][features-list] to document
    * [x] Features' flag ;
    * [ ] Prompt symbol ;
* [x] Default are defined in [`conf.d/pure.fish`][default] for:
  * [x] Feature flag ;
  * [ ] Symbol ;
* [x] Tests are passing (we can help you :hugs: ):
  * [x] Configs are tested (cf. [tests/_pure.test.fish][config-test]) ;
  * [x] Feature is tested in `tests/feature_name.test.fish` ;
* [ ] Customization is available ;
* [x] Feature is implemented.

[default]: /pure-fish/pure/blob/master/conf.d/pure.fish
[config-test]: /pure-fish/pure/blob/master/tests/_pure.test.fish
[contributing]: /pure-fish/pure/blob/master/CONTRIBUTING.md
[features-overview]: /pure-fish/pure/blob/master/docs/components/features-overview.md
[README]: /pure-fish/pure/blob/master/README.md
[features-list]: /pure-fish/pure/blob/master/docs/components/features-list.md
