### PR TITLE
update documentation for `pure_system_time_format`

### DIFF
--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -47,7 +47,7 @@ _pure_set_default pure_color_jobs pure_color_normal
 
 # Show system time
 _pure_set_default pure_show_system_time false
-_pure_set_default pure_system_time_format '+%T' # 12 hour time: '+%I:%M:%S %p'
+_pure_set_default pure_system_time_format '+%T' # 12 hour time: '+%-I:%M:%S %p'
 _pure_set_default pure_color_system_time pure_color_mute
 
 # Nix build environment

--- a/docs/components/features-list.md
+++ b/docs/components/features-list.md
@@ -283,7 +283,7 @@
 | Option                                     | Default | Description                                                         |
 | :----------------------------------------- | :------ | :------------------------------------------------------------------ |
 | **`pure_show_system_time`**                | `false` | `true`: shows system time before the prompt symbol (as `%H:%M:%S`). |
-| **`pure_system_time_format`**              | `+%T`   | `true`: shows system time in 12-hour time instead of 24-hour time.  |
+| **`pure_system_time_format`**              | `+%T`   | format for system time if shown (12 hour time is `+%-I:%M:%S %p`).  |
 
 === "Show system time (enabled)"
 


### PR DESCRIPTION
Follow up to #412 , fixes a doc mistake I made